### PR TITLE
Refactoring

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,23 +27,19 @@ check.smt2: picorv32.v
 test_sp: testbench_sp.exe firmware/firmware.hex
 	vvp -N testbench_sp.exe
 
-test_axi: testbench_axi.exe firmware/firmware.hex
-	vvp -N testbench_axi.exe
+test_axi: testbench.exe firmware/firmware.hex
+	vvp -N testbench.exe +axi_test
 
 test_synth: testbench_synth.exe firmware/firmware.hex
 	vvp -N testbench_synth.exe
 
-testbench.exe: testbench.v picorv32.v
-	iverilog -o testbench.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) testbench.v picorv32.v
+testbench.exe: testbench.v axi4_memory.v picorv32.v
+	iverilog -o testbench.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) testbench.v axi4_memory.v picorv32.v
 	chmod -x testbench.exe
 
-testbench_sp.exe: testbench.v picorv32.v
-	iverilog -o testbench_sp.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) -DSP_TEST testbench.v picorv32.v
+testbench_sp.exe: testbench.v axi4_memory.v picorv32.v
+	iverilog -o testbench_sp.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) -DSP_TEST testbench.v axi4_memory.v picorv32.v
 	chmod -x testbench_sp.exe
-
-testbench_axi.exe: testbench.v picorv32.v
-	iverilog -o testbench_axi.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) -DAXI_TEST testbench.v picorv32.v
-	chmod -x testbench_axi.exe
 
 testbench_synth.exe: testbench.v synth.v
 	iverilog -o testbench_synth.exe testbench.v synth.v
@@ -81,7 +77,7 @@ toc:
 clean:
 	rm -vrf $(FIRMWARE_OBJS) $(TEST_OBJS) check.smt2 check.vcd synth.v synth.log \
 		firmware/firmware.elf firmware/firmware.bin firmware/firmware.hex firmware/firmware.map \
-		testbench.exe testbench_sp.exe testbench_axi.exe testbench_synth.exe testbench.vcd
+		testbench.exe testbench_sp.exe testbench_synth.exe testbench.vcd
 
 .PHONY: test view test_sp test_axi test_synth toc clean
 

--- a/Makefile
+++ b/Makefile
@@ -33,12 +33,12 @@ test_axi: testbench.exe firmware/firmware.hex
 test_synth: testbench_synth.exe firmware/firmware.hex
 	vvp -N testbench_synth.exe
 
-testbench.exe: testbench.v axi4_memory.v picorv32.v
-	iverilog -o testbench.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) testbench.v axi4_memory.v picorv32.v
+testbench.exe: testbench.v picorv32_wrapper.v axi4_memory.v picorv32.v
+	iverilog -o testbench.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) testbench.v picorv32_wrapper.v axi4_memory.v picorv32.v
 	chmod -x testbench.exe
 
-testbench_sp.exe: testbench.v axi4_memory.v picorv32.v
-	iverilog -o testbench_sp.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) -DSP_TEST testbench.v axi4_memory.v picorv32.v
+testbench_sp.exe: testbench.v picorv32_wrapper.v axi4_memory.v picorv32.v
+	iverilog -o testbench_sp.exe $(subst $(COMPRESSED_ISA),C,-DCOMPRESSED_ISA) -DSP_TEST testbench.v picorv32_wrapper.v axi4_memory.v picorv32.v
 	chmod -x testbench_sp.exe
 
 testbench_synth.exe: testbench.v synth.v

--- a/axi4_memory.v
+++ b/axi4_memory.v
@@ -1,0 +1,193 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+module axi4_memory #(
+	parameter AXI_TEST = 0,
+	parameter VERBOSE = 0
+) (
+	input             clk,
+	input             mem_axi_awvalid,
+	output reg        mem_axi_awready = 0,
+	input [31:0]      mem_axi_awaddr,
+	input [ 2:0]      mem_axi_awprot,
+
+	input            mem_axi_wvalid,
+	output reg       mem_axi_wready = 0,
+	input [31:0]     mem_axi_wdata,
+	input [ 3:0]     mem_axi_wstrb,
+
+	output reg       mem_axi_bvalid = 0,
+	input            mem_axi_bready,
+
+	input            mem_axi_arvalid,
+	output reg       mem_axi_arready = 0,
+	input [31:0]     mem_axi_araddr,
+	input [ 2:0]     mem_axi_arprot,
+
+	output            mem_axi_rvalid = 0,
+	input             mem_axi_rready,
+	output reg [31:0] mem_axi_rdata
+);
+
+	reg [31:0]   memory [0:64*1024/4-1] /* verilator public */;
+	reg verbose;
+	initial verbose = $test$plusargs("verbose") || VERBOSE;
+
+	reg axi_test;
+	initial axi_test = $test$plusargs("axi_test") || AXI_TEST;
+
+	reg [63:0] xorshift64_state = 64'd88172645463325252;
+
+	task xorshift64_next;
+		begin
+			// see page 4 of Marsaglia, George (July 2003). "Xorshift RNGs". Journal of Statistical Software 8 (14).
+			xorshift64_state = xorshift64_state ^ (xorshift64_state << 13);
+			xorshift64_state = xorshift64_state ^ (xorshift64_state >>  7);
+			xorshift64_state = xorshift64_state ^ (xorshift64_state << 17);
+		end
+	endtask
+
+	reg [2:0] fast_axi_transaction = ~0;
+	reg [4:0] async_axi_transaction = ~0;
+	reg [4:0] delay_axi_transaction = 0;
+
+	always @(posedge clk) begin
+if (axi_test) begin
+		xorshift64_next;
+		{fast_axi_transaction, async_axi_transaction, delay_axi_transaction} <= xorshift64_state;
+end
+	end
+
+	reg latched_raddr_en = 0;
+	reg latched_waddr_en = 0;
+	reg latched_wdata_en = 0;
+
+	reg fast_raddr = 0;
+	reg fast_waddr = 0;
+	reg fast_wdata = 0;
+
+	reg [31:0] latched_raddr;
+	reg [31:0] latched_waddr;
+	reg [31:0] latched_wdata;
+	reg [ 3:0] latched_wstrb;
+	reg        latched_rinsn;
+
+	task handle_axi_arvalid; begin
+		mem_axi_arready <= 1;
+		latched_raddr = mem_axi_araddr;
+		latched_rinsn = mem_axi_arprot[2];
+		latched_raddr_en = 1;
+		fast_raddr <= 1;
+	end endtask
+
+	task handle_axi_awvalid; begin
+		mem_axi_awready <= 1;
+		latched_waddr = mem_axi_awaddr;
+		latched_waddr_en = 1;
+		fast_waddr <= 1;
+	end endtask
+
+	task handle_axi_wvalid; begin
+		mem_axi_wready <= 1;
+		latched_wdata = mem_axi_wdata;
+		latched_wstrb = mem_axi_wstrb;
+		latched_wdata_en = 1;
+		fast_wdata <= 1;
+	end endtask
+
+	task handle_axi_rvalid; begin
+if(verbose)
+		$display("RD: ADDR=%08x DATA=%08x%s", latched_raddr, memory[latched_raddr >> 2], latched_rinsn ? " INSN" : "");
+		if (latched_raddr < 64*1024) begin
+			mem_axi_rdata <= memory[latched_raddr >> 2];
+			mem_axi_rvalid <= 1;
+			latched_raddr_en = 0;
+		end else begin
+			$display("OUT-OF-BOUNDS MEMORY READ FROM %08x", latched_raddr);
+			$finish;
+		end
+	end endtask
+
+	task handle_axi_bvalid; begin
+if (verbose)
+		$display("WR: ADDR=%08x DATA=%08x STRB=%04b", latched_waddr, latched_wdata, latched_wstrb);
+		if (latched_waddr < 64*1024) begin
+			if (latched_wstrb[0]) memory[latched_waddr >> 2][ 7: 0] <= latched_wdata[ 7: 0];
+			if (latched_wstrb[1]) memory[latched_waddr >> 2][15: 8] <= latched_wdata[15: 8];
+			if (latched_wstrb[2]) memory[latched_waddr >> 2][23:16] <= latched_wdata[23:16];
+			if (latched_wstrb[3]) memory[latched_waddr >> 2][31:24] <= latched_wdata[31:24];
+		end else
+		if (latched_waddr == 32'h1000_0000) begin
+if (verbose) begin
+			if (32 <= latched_wdata && latched_wdata < 128)
+				$display("OUT: '%c'", latched_wdata[7:0]);
+			else
+				$display("OUT: %3d", latched_wdata);
+end else begin
+			$write("%c", latched_wdata[7:0]);
+`ifndef VERILATOR
+			$fflush();
+`endif
+end
+		end else begin
+			$display("OUT-OF-BOUNDS MEMORY WRITE TO %08x", latched_waddr);
+			$finish;
+		end
+		mem_axi_bvalid <= 1;
+		latched_waddr_en = 0;
+		latched_wdata_en = 0;
+	end endtask
+
+	always @(negedge clk) begin
+		if (mem_axi_arvalid && !(latched_raddr_en || fast_raddr) && async_axi_transaction[0]) handle_axi_arvalid;
+		if (mem_axi_awvalid && !(latched_waddr_en || fast_waddr) && async_axi_transaction[1]) handle_axi_awvalid;
+		if (mem_axi_wvalid  && !(latched_wdata_en || fast_wdata) && async_axi_transaction[2]) handle_axi_wvalid;
+		if (!mem_axi_rvalid && latched_raddr_en && async_axi_transaction[3]) handle_axi_rvalid;
+		if (!mem_axi_bvalid && latched_waddr_en && latched_wdata_en && async_axi_transaction[4]) handle_axi_bvalid;
+	end
+
+	always @(posedge clk) begin
+		mem_axi_arready <= 0;
+		mem_axi_awready <= 0;
+		mem_axi_wready <= 0;
+
+		fast_raddr <= 0;
+		fast_waddr <= 0;
+		fast_wdata <= 0;
+
+		if (mem_axi_rvalid && mem_axi_rready) begin
+			mem_axi_rvalid <= 0;
+		end
+
+		if (mem_axi_bvalid && mem_axi_bready) begin
+			mem_axi_bvalid <= 0;
+		end
+
+		if (mem_axi_arvalid && mem_axi_arready && !fast_raddr) begin
+			latched_raddr = mem_axi_araddr;
+			latched_rinsn = mem_axi_arprot[2];
+			latched_raddr_en = 1;
+		end
+
+		if (mem_axi_awvalid && mem_axi_awready && !fast_waddr) begin
+			latched_waddr = mem_axi_awaddr;
+			latched_waddr_en = 1;
+		end
+
+		if (mem_axi_wvalid && mem_axi_wready && !fast_wdata) begin
+			latched_wdata = mem_axi_wdata;
+			latched_wstrb = mem_axi_wstrb;
+			latched_wdata_en = 1;
+		end
+
+		if (mem_axi_arvalid && !(latched_raddr_en || fast_raddr) && !delay_axi_transaction[0]) handle_axi_arvalid;
+		if (mem_axi_awvalid && !(latched_waddr_en || fast_waddr) && !delay_axi_transaction[1]) handle_axi_awvalid;
+		if (mem_axi_wvalid  && !(latched_wdata_en || fast_wdata) && !delay_axi_transaction[2]) handle_axi_wvalid;
+
+		if (!mem_axi_rvalid && latched_raddr_en && !delay_axi_transaction[3]) handle_axi_rvalid;
+		if (!mem_axi_bvalid && latched_waddr_en && latched_wdata_en && !delay_axi_transaction[4]) handle_axi_bvalid;
+	end
+endmodule

--- a/picorv32_wrapper.v
+++ b/picorv32_wrapper.v
@@ -1,0 +1,118 @@
+// This is free and unencumbered software released into the public domain.
+//
+// Anyone is free to copy, modify, publish, use, compile, sell, or
+// distribute this software, either in source code form or as a compiled
+// binary, for any purpose, commercial or non-commercial, and by any
+// means.
+
+module picorv32_wrapper #(
+	parameter AXI_TEST = 0,
+	parameter VERBOSE = 0
+) (
+	input clk,
+	input resetn
+);
+
+	wire       trap;
+	reg [31:0] irq;
+
+	always @* begin
+		irq = 0;
+		irq[4] = &uut.picorv32_core.count_cycle[12:0];
+		irq[5] = &uut.picorv32_core.count_cycle[15:0];
+	end
+
+	wire        mem_axi_awvalid;
+	wire        mem_axi_awready;
+	wire [31:0] mem_axi_awaddr;
+	wire [ 2:0] mem_axi_awprot;
+
+	wire        mem_axi_wvalid;
+	wire        mem_axi_wready;
+	wire [31:0] mem_axi_wdata;
+	wire [ 3:0] mem_axi_wstrb;
+
+	wire        mem_axi_bvalid;
+	wire        mem_axi_bready;
+
+	wire        mem_axi_arvalid;
+	wire        mem_axi_arready;
+	wire [31:0] mem_axi_araddr;
+	wire [ 2:0] mem_axi_arprot;
+
+	wire        mem_axi_rvalid;
+	wire        mem_axi_rready;
+	wire [31:0] mem_axi_rdata;
+
+	axi4_memory #(
+		.AXI_TEST (AXI_TEST),
+		.VERBOSE  (VERBOSE)
+	) mem (
+		.clk             (clk             ),
+		.mem_axi_awvalid (mem_axi_awvalid ),
+		.mem_axi_awready (mem_axi_awready ),
+		.mem_axi_awaddr  (mem_axi_awaddr  ),
+		.mem_axi_awprot  (mem_axi_awprot  ),
+
+		.mem_axi_wvalid  (mem_axi_wvalid  ),
+		.mem_axi_wready  (mem_axi_wready  ),
+		.mem_axi_wdata   (mem_axi_wdata   ),
+		.mem_axi_wstrb   (mem_axi_wstrb   ),
+
+		.mem_axi_bvalid  (mem_axi_bvalid  ),
+		.mem_axi_bready  (mem_axi_bready  ),
+
+		.mem_axi_arvalid (mem_axi_arvalid ),
+		.mem_axi_arready (mem_axi_arready ),
+		.mem_axi_araddr  (mem_axi_araddr  ),
+		.mem_axi_arprot  (mem_axi_arprot  ),
+
+		.mem_axi_rvalid  (mem_axi_rvalid  ),
+		.mem_axi_rready  (mem_axi_rready  ),
+		.mem_axi_rdata   (mem_axi_rdata   )
+	);
+
+	picorv32_axi #(
+`ifdef SP_TEST
+		.ENABLE_REGS_DUALPORT(0),
+`endif
+		.ENABLE_MUL(1),
+		.ENABLE_IRQ(1)
+	) uut (
+		.clk            (clk            ),
+		.resetn         (resetn         ),
+		.trap           (trap           ),
+		.mem_axi_awvalid(mem_axi_awvalid),
+		.mem_axi_awready(mem_axi_awready),
+		.mem_axi_awaddr (mem_axi_awaddr ),
+		.mem_axi_awprot (mem_axi_awprot ),
+		.mem_axi_wvalid (mem_axi_wvalid ),
+		.mem_axi_wready (mem_axi_wready ),
+		.mem_axi_wdata  (mem_axi_wdata  ),
+		.mem_axi_wstrb  (mem_axi_wstrb  ),
+		.mem_axi_bvalid (mem_axi_bvalid ),
+		.mem_axi_bready (mem_axi_bready ),
+		.mem_axi_arvalid(mem_axi_arvalid),
+		.mem_axi_arready(mem_axi_arready),
+		.mem_axi_araddr (mem_axi_araddr ),
+		.mem_axi_arprot (mem_axi_arprot ),
+		.mem_axi_rvalid (mem_axi_rvalid ),
+		.mem_axi_rready (mem_axi_rready ),
+		.mem_axi_rdata  (mem_axi_rdata  ),
+		.irq            (irq            )
+	);
+
+	initial $readmemh("firmware/firmware.hex", mem.memory);
+
+	integer cycle_counter;
+	always @(posedge clk) begin
+		cycle_counter <= resetn ? cycle_counter + 1 : 0;
+		if (resetn && trap) begin
+`ifndef VERILATOR
+			repeat (10) @(posedge clk);
+`endif
+			$display("TRAP after %1d clock cycles", cycle_counter);
+			$finish;
+		end
+	end
+endmodule

--- a/picorv32_wrapper.v
+++ b/picorv32_wrapper.v
@@ -102,7 +102,12 @@ module picorv32_wrapper #(
 		.irq            (irq            )
 	);
 
-	initial $readmemh("firmware/firmware.hex", mem.memory);
+	reg [1023:0] firmware_file;
+	initial begin
+		if(!$value$plusargs("firmware=%s", firmware_file))
+			firmware_file = "firmware/firmware.hex";
+		$readmemh(firmware_file, mem.memory);
+	end
 
 	integer cycle_counter;
 	always @(posedge clk) begin

--- a/testbench.v
+++ b/testbench.v
@@ -8,7 +8,10 @@
 `timescale 1 ns / 1 ps
 // `define VERBOSE
 
-module testbench;
+module testbench #(
+	parameter AXI_TEST = 0,
+	parameter VERBOSE = 0
+);
 
 	reg clk = 1;
 	reg resetn = 0;
@@ -29,26 +32,54 @@ module testbench;
 	end
 
 	wire        mem_axi_awvalid;
-	reg         mem_axi_awready = 0;
+	wire        mem_axi_awready;
 	wire [31:0] mem_axi_awaddr;
 	wire [ 2:0] mem_axi_awprot;
 
 	wire        mem_axi_wvalid;
-	reg         mem_axi_wready = 0;
+	wire        mem_axi_wready;
 	wire [31:0] mem_axi_wdata;
 	wire [ 3:0] mem_axi_wstrb;
 
-	reg  mem_axi_bvalid = 0;
-	wire mem_axi_bready;
+	wire        mem_axi_bvalid;
+	wire        mem_axi_bready;
 
 	wire        mem_axi_arvalid;
-	reg         mem_axi_arready = 0;
+	wire        mem_axi_arready;
 	wire [31:0] mem_axi_araddr;
 	wire [ 2:0] mem_axi_arprot;
 
-	reg         mem_axi_rvalid = 0;
+	wire        mem_axi_rvalid;
 	wire        mem_axi_rready;
-	reg  [31:0] mem_axi_rdata;
+	wire [31:0] mem_axi_rdata;
+
+	axi4_memory #(
+		.AXI_TEST (AXI_TEST),
+		.VERBOSE  (VERBOSE)
+	) mem (
+		.clk             (clk             ),
+		.mem_axi_awvalid (mem_axi_awvalid ),
+		.mem_axi_awready (mem_axi_awready ),
+		.mem_axi_awaddr  (mem_axi_awaddr  ),
+		.mem_axi_awprot  (mem_axi_awprot  ),
+
+		.mem_axi_wvalid  (mem_axi_wvalid  ),
+		.mem_axi_wready  (mem_axi_wready  ),
+		.mem_axi_wdata   (mem_axi_wdata   ),
+		.mem_axi_wstrb   (mem_axi_wstrb   ),
+
+		.mem_axi_bvalid  (mem_axi_bvalid  ),
+		.mem_axi_bready  (mem_axi_bready  ),
+
+		.mem_axi_arvalid (mem_axi_arvalid ),
+		.mem_axi_arready (mem_axi_arready ),
+		.mem_axi_araddr  (mem_axi_araddr  ),
+		.mem_axi_arprot  (mem_axi_arprot  ),
+
+		.mem_axi_rvalid  (mem_axi_rvalid  ),
+		.mem_axi_rready  (mem_axi_rready  ),
+		.mem_axi_rdata   (mem_axi_rdata   )
+	);
 
 	picorv32_axi #(
 `ifdef SP_TEST
@@ -80,160 +111,7 @@ module testbench;
 		.irq            (irq            )
 	);
 
-	reg [31:0] memory [0:64*1024/4-1];
-	initial $readmemh("firmware/firmware.hex", memory);
-
-	reg [63:0] xorshift64_state = 64'd88172645463325252;
-
-	task xorshift64_next;
-		begin
-			// see page 4 of Marsaglia, George (July 2003). "Xorshift RNGs". Journal of Statistical Software 8 (14).
-			xorshift64_state = xorshift64_state ^ (xorshift64_state << 13);
-			xorshift64_state = xorshift64_state ^ (xorshift64_state >>  7);
-			xorshift64_state = xorshift64_state ^ (xorshift64_state << 17);
-		end
-	endtask
-
-	reg [2:0] fast_axi_transaction = ~0;
-	reg [4:0] async_axi_transaction = ~0;
-	reg [4:0] delay_axi_transaction = 0;
-
-`ifdef AXI_TEST
-	always @(posedge clk) begin
-		xorshift64_next;
-		{fast_axi_transaction, async_axi_transaction, delay_axi_transaction} <= xorshift64_state;
-	end
-`endif
-
-	reg latched_raddr_en = 0;
-	reg latched_waddr_en = 0;
-	reg latched_wdata_en = 0;
-
-	reg fast_raddr = 0;
-	reg fast_waddr = 0;
-	reg fast_wdata = 0;
-
-	reg [31:0] latched_raddr;
-	reg [31:0] latched_waddr;
-	reg [31:0] latched_wdata;
-	reg [ 3:0] latched_wstrb;
-	reg        latched_rinsn;
-
-	task handle_axi_arvalid; begin
-		mem_axi_arready <= 1;
-		latched_raddr = mem_axi_araddr;
-		latched_rinsn = mem_axi_arprot[2];
-		latched_raddr_en = 1;
-		fast_raddr <= 1;
-	end endtask
-
-	task handle_axi_awvalid; begin
-		mem_axi_awready <= 1;
-		latched_waddr = mem_axi_awaddr;
-		latched_waddr_en = 1;
-		fast_waddr <= 1;
-	end endtask
-
-	task handle_axi_wvalid; begin
-		mem_axi_wready <= 1;
-		latched_wdata = mem_axi_wdata;
-		latched_wstrb = mem_axi_wstrb;
-		latched_wdata_en = 1;
-		fast_wdata <= 1;
-	end endtask
-
-	task handle_axi_rvalid; begin
-`ifdef VERBOSE
-		$display("RD: ADDR=%08x DATA=%08x%s", latched_raddr, memory[latched_raddr >> 2], latched_rinsn ? " INSN" : "");
-`endif
-		if (latched_raddr < 64*1024) begin
-			mem_axi_rdata <= memory[latched_raddr >> 2];
-			mem_axi_rvalid <= 1;
-			latched_raddr_en = 0;
-		end else begin
-			$display("OUT-OF-BOUNDS MEMORY READ FROM %08x", latched_raddr);
-			$finish;
-		end
-	end endtask
-
-	task handle_axi_bvalid; begin
-`ifdef VERBOSE
-		$display("WR: ADDR=%08x DATA=%08x STRB=%04b", latched_waddr, latched_wdata, latched_wstrb);
-`endif
-		if (latched_waddr < 64*1024) begin
-			if (latched_wstrb[0]) memory[latched_waddr >> 2][ 7: 0] <= latched_wdata[ 7: 0];
-			if (latched_wstrb[1]) memory[latched_waddr >> 2][15: 8] <= latched_wdata[15: 8];
-			if (latched_wstrb[2]) memory[latched_waddr >> 2][23:16] <= latched_wdata[23:16];
-			if (latched_wstrb[3]) memory[latched_waddr >> 2][31:24] <= latched_wdata[31:24];
-		end else
-		if (latched_waddr == 32'h1000_0000) begin
-`ifdef VERBOSE
-			if (32 <= latched_wdata && latched_wdata < 128)
-				$display("OUT: '%c'", latched_wdata);
-			else
-				$display("OUT: %3d", latched_wdata);
-`else
-			$write("%c", latched_wdata);
-			$fflush();
-`endif
-		end else begin
-			$display("OUT-OF-BOUNDS MEMORY WRITE TO %08x", latched_waddr);
-			$finish;
-		end
-		mem_axi_bvalid <= 1;
-		latched_waddr_en = 0;
-		latched_wdata_en = 0;
-	end endtask
-
-	always @(negedge clk) begin
-		if (mem_axi_arvalid && !(latched_raddr_en || fast_raddr) && async_axi_transaction[0]) handle_axi_arvalid;
-		if (mem_axi_awvalid && !(latched_waddr_en || fast_waddr) && async_axi_transaction[1]) handle_axi_awvalid;
-		if (mem_axi_wvalid  && !(latched_wdata_en || fast_wdata) && async_axi_transaction[2]) handle_axi_wvalid;
-		if (!mem_axi_rvalid && latched_raddr_en && async_axi_transaction[3]) handle_axi_rvalid;
-		if (!mem_axi_bvalid && latched_waddr_en && latched_wdata_en && async_axi_transaction[4]) handle_axi_bvalid;
-	end
-
-	always @(posedge clk) begin
-		mem_axi_arready <= 0;
-		mem_axi_awready <= 0;
-		mem_axi_wready <= 0;
-
-		fast_raddr <= 0;
-		fast_waddr <= 0;
-		fast_wdata <= 0;
-
-		if (mem_axi_rvalid && mem_axi_rready) begin
-			mem_axi_rvalid <= 0;
-		end
-
-		if (mem_axi_bvalid && mem_axi_bready) begin
-			mem_axi_bvalid <= 0;
-		end
-
-		if (mem_axi_arvalid && mem_axi_arready && !fast_raddr) begin
-			latched_raddr = mem_axi_araddr;
-			latched_rinsn = mem_axi_arprot[2];
-			latched_raddr_en = 1;
-		end
-
-		if (mem_axi_awvalid && mem_axi_awready && !fast_waddr) begin
-			latched_waddr = mem_axi_awaddr;
-			latched_waddr_en = 1;
-		end
-
-		if (mem_axi_wvalid && mem_axi_wready && !fast_wdata) begin
-			latched_wdata = mem_axi_wdata;
-			latched_wstrb = mem_axi_wstrb;
-			latched_wdata_en = 1;
-		end
-
-		if (mem_axi_arvalid && !(latched_raddr_en || fast_raddr) && !delay_axi_transaction[0]) handle_axi_arvalid;
-		if (mem_axi_awvalid && !(latched_waddr_en || fast_waddr) && !delay_axi_transaction[1]) handle_axi_awvalid;
-		if (mem_axi_wvalid  && !(latched_wdata_en || fast_wdata) && !delay_axi_transaction[2]) handle_axi_wvalid;
-
-		if (!mem_axi_rvalid && latched_raddr_en && !delay_axi_transaction[3]) handle_axi_rvalid;
-		if (!mem_axi_bvalid && latched_waddr_en && latched_wdata_en && !delay_axi_transaction[4]) handle_axi_bvalid;
-	end
+	initial $readmemh("firmware/firmware.hex", mem.memory);
 
 	initial begin
 		if ($test$plusargs("vcd")) begin

--- a/testbench.v
+++ b/testbench.v
@@ -15,14 +15,6 @@ module testbench #(
 
 	reg clk = 1;
 	reg resetn = 0;
-	reg [31:0] irq;
-	wire trap;
-
-	always @* begin
-		irq = 0;
-		irq[4] = &uut.picorv32_core.count_cycle[12:0];
-		irq[5] = &uut.picorv32_core.count_cycle[15:0];
-	end
 
 	always #5 clk = ~clk;
 
@@ -30,88 +22,6 @@ module testbench #(
 		repeat (100) @(posedge clk);
 		resetn <= 1;
 	end
-
-	wire        mem_axi_awvalid;
-	wire        mem_axi_awready;
-	wire [31:0] mem_axi_awaddr;
-	wire [ 2:0] mem_axi_awprot;
-
-	wire        mem_axi_wvalid;
-	wire        mem_axi_wready;
-	wire [31:0] mem_axi_wdata;
-	wire [ 3:0] mem_axi_wstrb;
-
-	wire        mem_axi_bvalid;
-	wire        mem_axi_bready;
-
-	wire        mem_axi_arvalid;
-	wire        mem_axi_arready;
-	wire [31:0] mem_axi_araddr;
-	wire [ 2:0] mem_axi_arprot;
-
-	wire        mem_axi_rvalid;
-	wire        mem_axi_rready;
-	wire [31:0] mem_axi_rdata;
-
-	axi4_memory #(
-		.AXI_TEST (AXI_TEST),
-		.VERBOSE  (VERBOSE)
-	) mem (
-		.clk             (clk             ),
-		.mem_axi_awvalid (mem_axi_awvalid ),
-		.mem_axi_awready (mem_axi_awready ),
-		.mem_axi_awaddr  (mem_axi_awaddr  ),
-		.mem_axi_awprot  (mem_axi_awprot  ),
-
-		.mem_axi_wvalid  (mem_axi_wvalid  ),
-		.mem_axi_wready  (mem_axi_wready  ),
-		.mem_axi_wdata   (mem_axi_wdata   ),
-		.mem_axi_wstrb   (mem_axi_wstrb   ),
-
-		.mem_axi_bvalid  (mem_axi_bvalid  ),
-		.mem_axi_bready  (mem_axi_bready  ),
-
-		.mem_axi_arvalid (mem_axi_arvalid ),
-		.mem_axi_arready (mem_axi_arready ),
-		.mem_axi_araddr  (mem_axi_araddr  ),
-		.mem_axi_arprot  (mem_axi_arprot  ),
-
-		.mem_axi_rvalid  (mem_axi_rvalid  ),
-		.mem_axi_rready  (mem_axi_rready  ),
-		.mem_axi_rdata   (mem_axi_rdata   )
-	);
-
-	picorv32_axi #(
-`ifdef SP_TEST
-		.ENABLE_REGS_DUALPORT(0),
-`endif
-		.ENABLE_MUL(1),
-		.ENABLE_IRQ(1)
-	) uut (
-		.clk            (clk            ),
-		.resetn         (resetn         ),
-		.trap           (trap           ),
-		.mem_axi_awvalid(mem_axi_awvalid),
-		.mem_axi_awready(mem_axi_awready),
-		.mem_axi_awaddr (mem_axi_awaddr ),
-		.mem_axi_awprot (mem_axi_awprot ),
-		.mem_axi_wvalid (mem_axi_wvalid ),
-		.mem_axi_wready (mem_axi_wready ),
-		.mem_axi_wdata  (mem_axi_wdata  ),
-		.mem_axi_wstrb  (mem_axi_wstrb  ),
-		.mem_axi_bvalid (mem_axi_bvalid ),
-		.mem_axi_bready (mem_axi_bready ),
-		.mem_axi_arvalid(mem_axi_arvalid),
-		.mem_axi_arready(mem_axi_arready),
-		.mem_axi_araddr (mem_axi_araddr ),
-		.mem_axi_arprot (mem_axi_arprot ),
-		.mem_axi_rvalid (mem_axi_rvalid ),
-		.mem_axi_rready (mem_axi_rready ),
-		.mem_axi_rdata  (mem_axi_rdata  ),
-		.irq            (irq            )
-	);
-
-	initial $readmemh("firmware/firmware.hex", mem.memory);
 
 	initial begin
 		if ($test$plusargs("vcd")) begin
@@ -123,13 +33,11 @@ module testbench #(
 		$finish;
 	end
 
-	integer cycle_counter;
-	always @(posedge clk) begin
-		cycle_counter <= resetn ? cycle_counter + 1 : 0;
-		if (resetn && trap) begin
-			repeat (10) @(posedge clk);
-			$display("TRAP after %1d clock cycles", cycle_counter);
-			$finish;
-		end
-	end
+	picorv32_wrapper #(
+		.AXI_TEST (AXI_TEST),
+		.VERBOSE  (VERBOSE)
+	) top (
+		.clk    (clk   ),
+		.resetn (resetn)
+	);
 endmodule


### PR DESCRIPTION
Some testbench refactoring to increase modularity and prepare for a Verilator testbench. I already have a verilator testbench in the picorv32 version that is found in the FuseSoC standard core library. This testbench however has dependencies on other cores in the library, and might need some changes to be helpful in a non-FuseSoC environment

This series also introduces some new plusargs to change firmware, verbosity and axi delay randomization without recompiling the testbench