### PR TITLE
Deassert pcpi_valid upon asserting sbreak IRQ

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -1270,6 +1270,7 @@ module picorv32 #(
 									cpu_state <= cpu_state_fetch;
 								end else
 								if (CATCH_ILLINSN && pcpi_timeout) begin
+								    pcpi_valid <= 0;
 									`debug($display("SBREAK OR UNSUPPORTED INSN AT 0x%08x", reg_pc);)
 									if (ENABLE_IRQ && !irq_mask[irq_sbreak] && !irq_active) begin
 										next_irq_pending[irq_sbreak] = 1;
@@ -1419,6 +1420,7 @@ module picorv32 #(
 							cpu_state <= cpu_state_fetch;
 						end else
 						if (CATCH_ILLINSN && pcpi_timeout) begin
+							pcpi_valid <= 0;
 							`debug($display("SBREAK OR UNSUPPORTED INSN AT 0x%08x", reg_pc);)
 							if (ENABLE_IRQ && !irq_mask[irq_sbreak] && !irq_active) begin
 								next_irq_pending[irq_sbreak] = 1;


### PR DESCRIPTION
This fixes #8

It leaves two potentially unanswered problems/new issues:

- Instructions such as `sbreak` take at least 16 cycles to trigger an IRQ, as they wait for PCPI timeout. Writing logic to IRQ immediately on `sbreak` and potentially `scall` instructions might be desirable. Alternatively, an external PCPI module could do this, but would then have to use a different IRQ line.
- I haven't examined how an sbreak or illegal instruction would be handled inside the ISR, but trapping seems logical.