### PR TITLE
Fast mul optimization

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -1889,7 +1889,8 @@ module picorv32_pcpi_fast_mul (
 	wire instr_rs2_signed = |{instr_mulh};
 
 	reg active1, active2, shift_out;
-	reg [63:0] rs1, rs2, rd;
+	reg [32:0] rs1, rs2;
+	reg [63:0] rd;
 
 	always @* begin
 		instr_mul = 0;


### PR DESCRIPTION
On Array 10, the very minor change below has the following impact:

- Uses 3 DSPs instead of 6
- Uses the output registers of the DSPs instead of using random logic output registers for rd. 
- As a result, timing improves from 200MHz to 300MHz+ !

It's clear the the real issue is with Quartus being to dumb to recognize this structure by itself, but such is life...

On a Cyclone 4, the impact is neglible: ~30 logic elements Iess (out of 5700 in my case.)
