### PR TITLE
Add toolchain prefix to objcopy

### DIFF
--- a/dhrystone/Makefile
+++ b/dhrystone/Makefile
@@ -29,7 +29,7 @@ timing.vvp: testbench.v ../picorv32.v
 	chmod -x timing.vvp
 
 dhry.hex: dhry.elf
-	riscv32-unknown-elf-objcopy -O verilog $< $@
+	$(TOOLCHAIN_PREFIX)objcopy -O verilog $< $@
 
 ifeq ($(USE_MYSTDLIB),1)
 dhry.elf: $(OBJS) sections.lds

--- a/dhrystone/testbench.v
+++ b/dhrystone/testbench.v
@@ -29,6 +29,7 @@ module testbench;
 	picorv32 #(
 		.BARREL_SHIFTER(1),
 		.ENABLE_MUL(1),
+		.ENABLE_FAST_MUL(1),
 		.ENABLE_DIV(1),
 		.PROGADDR_RESET('h10000),
 		.STACKADDR('h10000)

--- a/picorv32.v
+++ b/picorv32.v
@@ -1889,7 +1889,8 @@ module picorv32_pcpi_fast_mul (
 	wire instr_rs2_signed = |{instr_mulh};
 
 	reg active1, active2, shift_out;
-	reg [63:0] rs1, rs2, rd;
+	reg [32:0] rs1, rs2;
+	reg [63:0] rd;
 
 	always @* begin
 		instr_mul = 0;


### PR DESCRIPTION
Fix for those (like me) who don't have the riscv toolchain in their path...