### PR TITLE
dhrystone with registered memory

### DIFF
--- a/dhrystone/Makefile
+++ b/dhrystone/Makefile
@@ -13,6 +13,9 @@ endif
 test: testbench.vvp dhry.hex
 	vvp -N testbench.vvp
 
+test_slow_mem: testbench_slow_mem.vvp dhry.hex
+	vvp -N testbench_slow_mem.vvp
+
 timing: timing.txt
 	grep '^##' timing.txt | gawk 'x != "" {print x,$$3-y;} {x=$$2;y=$$3;}' | sort | uniq -c | \
 		gawk '{printf("%03d-%-7s %2d %-8s (%d)\n",$$3,$$2,$$3,$$2,$$1);}' | sort | cut -c13-
@@ -23,6 +26,10 @@ timing.txt: timing.vvp dhry.hex
 testbench.vvp: testbench.v ../picorv32.v
 	iverilog -o testbench.vvp testbench.v ../picorv32.v
 	chmod -x testbench.vvp
+
+testbench_slow_mem.vvp: testbench_slow_mem.v ../picorv32.v
+	iverilog -o testbench_slow_mem.vvp testbench_slow_mem.v ../picorv32.v
+	chmod -x testbench_slow_mem.vvp
 
 timing.vvp: testbench.v ../picorv32.v
 	iverilog -o timing.vvp -DTIMING testbench.v ../picorv32.v
@@ -50,7 +57,7 @@ endif
 dhry_1.o dhry_2.o: CFLAGS += -Wno-implicit-int -Wno-implicit-function-declaration
 
 clean:
-	rm -rf *.o *.d dhry.elf dhry.map dhry.bin dhry.hex testbench.vvp testbench.vcd timing.vvp timing.txt
+	rm -rf *.o *.d dhry.elf dhry.map dhry.bin dhry.hex testbench.vvp testbench.vcd timing.vvp timing.txt testbench_slow_mem.vvp
 
 .PHONY: test clean
 

--- a/dhrystone/testbench_slow_mem.v
+++ b/dhrystone/testbench_slow_mem.v
@@ -1,0 +1,114 @@
+`timescale 1 ns / 1 ps
+
+module testbench;
+	reg clk = 1;
+	reg resetn = 0;
+	wire trap;
+
+	always #5 clk = ~clk;
+
+	initial begin
+		repeat (100) @(posedge clk);
+		resetn <= 1;
+	end
+
+	wire mem_valid;
+    reg  mem_valid_q;
+	wire mem_instr;
+	reg  mem_ready;
+	wire [31:0] mem_addr;
+	wire [31:0] mem_wdata;
+	wire [3:0]  mem_wstrb;
+	reg  [31:0] mem_rdata;
+
+	picorv32 #(
+		.BARREL_SHIFTER(1),
+		.ENABLE_FAST_MUL(1),
+		.ENABLE_DIV(1),
+		.PROGADDR_RESET('h10000),
+		.STACKADDR('h10000)
+	) uut (
+		.clk         (clk        ),
+		.resetn      (resetn     ),
+		.trap        (trap       ),
+		.mem_valid   (mem_valid  ),
+		.mem_instr   (mem_instr  ),
+		.mem_ready   (mem_ready  ),
+		.mem_addr    (mem_addr   ),
+		.mem_wdata   (mem_wdata  ),
+		.mem_wstrb   (mem_wstrb  ),
+		.mem_rdata   (mem_rdata  ),
+		.mem_la_read (),
+		.mem_la_write(),
+		.mem_la_addr (),
+		.mem_la_wdata(),
+		.mem_la_wstrb()
+	);
+
+	reg [7:0] memory [0:256*1024-1];
+	initial $readmemh("dhry.hex", memory);
+
+	always @(posedge clk) begin
+        mem_ready <= 1'b0;
+
+	    mem_rdata[ 7: 0] <= 'bx;
+        mem_rdata[15: 8] <= 'bx;
+        mem_rdata[23:16] <= 'bx;
+        mem_rdata[31:24] <= 'bx;
+
+		if (mem_valid & !mem_valid_q) begin
+            if (|mem_wstrb) begin
+                mem_ready <= 1'b1;
+
+			    case (mem_addr)
+    				32'h1000_0000: begin
+`ifndef TIMING
+    					$write("%c", mem_wdata);
+    					$fflush();
+`endif
+    				end
+    				default: begin
+    					if (mem_wstrb[0]) memory[mem_addr + 0] <= mem_wdata[ 7: 0];
+    					if (mem_wstrb[1]) memory[mem_addr + 1] <= mem_wdata[15: 8];
+    					if (mem_wstrb[2]) memory[mem_addr + 2] <= mem_wdata[23:16];
+    					if (mem_wstrb[3]) memory[mem_addr + 3] <= mem_wdata[31:24];
+    				end
+    			endcase
+            end
+            else begin
+                mem_ready <= 1'b1;
+
+      		    mem_rdata[ 7: 0] <= memory[mem_addr + 0];
+    		    mem_rdata[15: 8] <= memory[mem_addr + 1];
+    		    mem_rdata[23:16] <= memory[mem_addr + 2];
+    		    mem_rdata[31:24] <= memory[mem_addr + 3];
+            end
+		end
+
+        mem_valid_q <= mem_valid;
+	end
+
+	initial begin
+		$dumpfile("testbench.vcd");
+		$dumpvars(0, testbench);
+	end
+
+	always @(posedge clk) begin
+		if (resetn && trap) begin
+			repeat (10) @(posedge clk);
+			$display("TRAP");
+			$finish;
+		end
+	end
+
+`ifdef TIMING
+	initial begin
+		repeat (100000) @(posedge clk);
+		$finish;
+	end
+	always @(posedge clk) begin
+		if (uut.dbg_next)
+			$display("## %-s %d", uut.dbg_ascii_instr ? uut.dbg_ascii_instr : "pcpi", uut.count_cycle);
+	end
+`endif
+endmodule

--- a/dhrystone/testbench_slow_mem.v
+++ b/dhrystone/testbench_slow_mem.v
@@ -13,7 +13,7 @@ module testbench;
 	end
 
 	wire mem_valid;
-    reg  mem_valid_q;
+	reg  mem_valid_q;
 	wire mem_instr;
 	reg  mem_ready;
 	wire [31:0] mem_addr;
@@ -49,43 +49,43 @@ module testbench;
 	initial $readmemh("dhry.hex", memory);
 
 	always @(posedge clk) begin
-        mem_ready <= 1'b0;
+		mem_ready <= 1'b0;
 
-	    mem_rdata[ 7: 0] <= 'bx;
-        mem_rdata[15: 8] <= 'bx;
-        mem_rdata[23:16] <= 'bx;
-        mem_rdata[31:24] <= 'bx;
+		mem_rdata[ 7: 0] <= 'bx;
+		mem_rdata[15: 8] <= 'bx;
+		mem_rdata[23:16] <= 'bx;
+		mem_rdata[31:24] <= 'bx;
 
 		if (mem_valid & !mem_valid_q) begin
-            if (|mem_wstrb) begin
-                mem_ready <= 1'b1;
+			if (|mem_wstrb) begin
+				mem_ready <= 1'b1;
 
-			    case (mem_addr)
-    				32'h1000_0000: begin
+				case (mem_addr)
+					32'h1000_0000: begin
 `ifndef TIMING
-    					$write("%c", mem_wdata);
-    					$fflush();
+						$write("%c", mem_wdata);
+						$fflush();
 `endif
-    				end
-    				default: begin
-    					if (mem_wstrb[0]) memory[mem_addr + 0] <= mem_wdata[ 7: 0];
-    					if (mem_wstrb[1]) memory[mem_addr + 1] <= mem_wdata[15: 8];
-    					if (mem_wstrb[2]) memory[mem_addr + 2] <= mem_wdata[23:16];
-    					if (mem_wstrb[3]) memory[mem_addr + 3] <= mem_wdata[31:24];
-    				end
-    			endcase
-            end
-            else begin
-                mem_ready <= 1'b1;
+					end
+					default: begin
+						if (mem_wstrb[0]) memory[mem_addr + 0] <= mem_wdata[ 7: 0];
+						if (mem_wstrb[1]) memory[mem_addr + 1] <= mem_wdata[15: 8];
+						if (mem_wstrb[2]) memory[mem_addr + 2] <= mem_wdata[23:16];
+						if (mem_wstrb[3]) memory[mem_addr + 3] <= mem_wdata[31:24];
+					end
+				endcase
+			end
+			else begin
+				mem_ready <= 1'b1;
 
-      		    mem_rdata[ 7: 0] <= memory[mem_addr + 0];
-    		    mem_rdata[15: 8] <= memory[mem_addr + 1];
-    		    mem_rdata[23:16] <= memory[mem_addr + 2];
-    		    mem_rdata[31:24] <= memory[mem_addr + 3];
-            end
+				mem_rdata[ 7: 0] <= memory[mem_addr + 0];
+				mem_rdata[15: 8] <= memory[mem_addr + 1];
+				mem_rdata[23:16] <= memory[mem_addr + 2];
+				mem_rdata[31:24] <= memory[mem_addr + 3];
+			end
 		end
 
-        mem_valid_q <= mem_valid;
+		mem_valid_q <= mem_valid;
 	end
 
 	initial begin


### PR DESCRIPTION
'make test_slow_mem' to run dhrystone on a testbench that has FPGA memory with input registers and output registers on the memory itself enabled.

This is useful to assess performance for cases where you want to run the core at maximum speed possible, one of the stated goals of picorv32 :-). Without those input and output registers, the critical path is often in the memory.
