### PR TITLE
Optional pipeline stages in front and after the fast multiplier

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -981,9 +981,9 @@ module picorv32 #(
 			instr_and   <= is_alu_reg_reg && mem_rdata_q[14:12] == 3'b111 && mem_rdata_q[31:25] == 7'b0000000;
 
 			instr_rdcycle  <= ((mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11000000000000000010) ||
-			                   (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11000000000100000010)) && ENABLE_COUNTERS;
+					   (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11000000000100000010)) && ENABLE_COUNTERS;
 			instr_rdcycleh <= ((mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11001000000000000010) ||
-			                   (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11001000000100000010)) && ENABLE_COUNTERS && ENABLE_COUNTERS64;
+					   (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11001000000100000010)) && ENABLE_COUNTERS && ENABLE_COUNTERS64;
 			instr_rdinstr  <=  (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11000000001000000010) && ENABLE_COUNTERS;
 			instr_rdinstrh <=  (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11001000001000000010) && ENABLE_COUNTERS && ENABLE_COUNTERS64;
 
@@ -1917,8 +1917,8 @@ module picorv32_pcpi_mul #(
 endmodule
 
 module picorv32_pcpi_fast_mul #(
-    parameter MAX_PIPELINED = 1
-    ) (
+	parameter MAX_PIPELINED = 1
+	) (
 	input clk, resetn,
 
 	input             pcpi_valid,
@@ -1931,12 +1931,12 @@ module picorv32_pcpi_fast_mul #(
 	output            pcpi_ready
 );
 
-    reg pcpi_valid_q;
-    always @(posedge clk) begin
-        pcpi_valid_q <= pcpi_valid;
-    end
+	reg pcpi_valid_q;
+	always @(posedge clk) begin
+		pcpi_valid_q <= pcpi_valid;
+	end
 
-    reg active_p0;
+	reg active_p0;
 	reg instr_mul_p0, instr_mulh_p0, instr_mulhsu_p0, instr_mulhu_p0;
 
 	always @* begin
@@ -1944,7 +1944,7 @@ module picorv32_pcpi_fast_mul #(
 		instr_mulh_p0   = 0;
 		instr_mulhsu_p0 = 0;
 		instr_mulhu_p0  = 0;
-        active_p0       = 0;
+		active_p0       = 0;
 
 		if (resetn && pcpi_valid && !pcpi_valid_q && pcpi_insn[6:0] == 7'b0110011 && pcpi_insn[31:25] == 7'b0000001) begin
 			case (pcpi_insn[14:12])
@@ -1954,7 +1954,7 @@ module picorv32_pcpi_fast_mul #(
 				3'b011: instr_mulhu_p0  = 1;
 			endcase
 
-            active_p0 = !pcpi_insn[14];
+			active_p0 = !pcpi_insn[14];
 		end
 	end
     
@@ -1963,49 +1963,49 @@ module picorv32_pcpi_fast_mul #(
 	wire instr_rs1_signed_p0 = |{instr_mulh_p0, instr_mulhsu_p0};
 	wire instr_rs2_signed_p0 = |{instr_mulh_p0};
 
-    reg active_p1;
+	reg active_p1;
 
-   	reg instr_any_mul_p1;
-   	reg instr_any_mulh_p1;
-   	reg instr_rs1_signed_p1;
-   	reg instr_rs2_signed_p1;
+	reg instr_any_mul_p1;
+	reg instr_any_mulh_p1;
+	reg instr_rs1_signed_p1;
+	reg instr_rs2_signed_p1;
 
-    reg [31:0] pcpi_rs1_p1;
-    reg [31:0] pcpi_rs2_p1;
+	reg [31:0] pcpi_rs1_p1;
+	reg [31:0] pcpi_rs2_p1;
 
-    generate if (MAX_PIPELINED) begin
+	generate if (MAX_PIPELINED) begin
     
-        always @(posedge clk) begin
-            if (active_p0) begin
+		always @(posedge clk) begin
+			if (active_p0) begin
 				instr_any_mul_p1    <= instr_any_mul_p0;
-            	instr_any_mulh_p1   <= instr_any_mulh_p0;
-            	instr_rs1_signed_p1 <= instr_rs1_signed_p0;
-            	instr_rs2_signed_p1 <= instr_rs2_signed_p0;
+				instr_any_mulh_p1   <= instr_any_mulh_p0;
+				instr_rs1_signed_p1 <= instr_rs1_signed_p0;
+				instr_rs2_signed_p1 <= instr_rs2_signed_p0;
 
-                pcpi_rs1_p1         <= pcpi_rs1;
-                pcpi_rs2_p1         <= pcpi_rs2;
-            end
+				pcpi_rs1_p1         <= pcpi_rs1;
+				pcpi_rs2_p1         <= pcpi_rs2;
+			end
 
-            active_p1           <= resetn && active_p0;
-        end
-    end else begin
-        // When no max pipelined, just collapse this stage.
-        always @* begin
-            active_p1           = resetn && active_p0;
+			active_p1           <= resetn && active_p0;
+		end
+	end else begin
+		// Just collapse this stage when pipelining is disabled.
+		always @* begin
+			active_p1           = resetn && active_p0;
 
-    	    instr_any_mul_p1    = active_p0 && instr_any_mul_p0;
-        	instr_any_mulh_p1   = active_p0 && instr_any_mulh_p0;
-        	instr_rs1_signed_p1 = instr_rs1_signed_p0;
-        	instr_rs2_signed_p1 = instr_rs2_signed_p0;
+			instr_any_mul_p1    = active_p0 && instr_any_mul_p0;
+			instr_any_mulh_p1   = active_p0 && instr_any_mulh_p0;
+			instr_rs1_signed_p1 = instr_rs1_signed_p0;
+			instr_rs2_signed_p1 = instr_rs2_signed_p0;
 
-            pcpi_rs1_p1         = pcpi_rs1;
-            pcpi_rs2_p1         = pcpi_rs2;
-        end
-    end endgenerate
+			pcpi_rs1_p1         = pcpi_rs1;
+			pcpi_rs2_p1         = pcpi_rs2;
+		end
+	end endgenerate
 
 	reg [32:0] rs1_p2, rs2_p2;
-    reg        active_p2;
-    reg        shift_out_p2;
+	reg        active_p2;
+	reg        shift_out_p2;
 
 	always @(posedge clk) begin
 		if (instr_any_mul_p1) begin
@@ -2026,35 +2026,35 @@ module picorv32_pcpi_fast_mul #(
 	end
 
 	reg [63:0] rd_p3;
-    reg        shift_out_p3;
-    reg        active_p3;
+	reg        shift_out_p3;
+	reg        active_p3;
 
 	always @(posedge clk) begin
 		rd_p3           <= $signed(rs1_p2) * $signed(rs2_p2);
-        shift_out_p3    <= shift_out_p2;
-        active_p3       <= resetn && active_p2;
+		shift_out_p3    <= shift_out_p2;
+		active_p3       <= resetn && active_p2;
 	end
 
 	reg [63:0] rd_p4;
-    reg        shift_out_p4;
-    reg        active_p4;
+	reg        shift_out_p4;
+	reg        active_p4;
 
-    generate if (MAX_PIPELINED) begin
-        always @(posedge clk) begin
-            if (active_p3) begin
-                rd_p4           <= rd_p3;
-                shift_out_p4    <= shift_out_p3;
-            end
-            active_p4       <= resetn && active_p3;
-        end
-    end
-    else begin
-        always @* begin
-            rd_p4           = rd_p3;
-            shift_out_p4    = shift_out_p3;
-            active_p4       = resetn && active_p3;
-        end
-    end endgenerate
+	generate if (MAX_PIPELINED) begin
+		always @(posedge clk) begin
+			if (active_p3) begin
+				rd_p4           <= rd_p3;
+				shift_out_p4    <= shift_out_p3;
+			end
+			active_p4       <= resetn && active_p3;
+		end
+	end
+	else begin
+		always @* begin
+			rd_p4           = rd_p3;
+			shift_out_p4    = shift_out_p3;
+			active_p4       = resetn && active_p3;
+		end
+	end endgenerate
 
 	assign pcpi_wr      = active_p4;
 	assign pcpi_wait    = 0;

--- a/picorv32.v
+++ b/picorv32.v
@@ -1917,7 +1917,7 @@ module picorv32_pcpi_mul #(
 endmodule
 
 module picorv32_pcpi_fast_mul #(
-	parameter MAX_PIPELINED = 0
+	parameter EXTRA_FFS = 0
 	) (
 	input clk, resetn,
 
@@ -1973,7 +1973,7 @@ module picorv32_pcpi_fast_mul #(
 	reg [31:0] pcpi_rs1_p1;
 	reg [31:0] pcpi_rs2_p1;
 
-	generate if (MAX_PIPELINED) begin
+	generate if (EXTRA_FFS) begin
     
 		always @(posedge clk) begin
 			if (active_p0) begin
@@ -2039,7 +2039,7 @@ module picorv32_pcpi_fast_mul #(
 	reg        shift_out_p4;
 	reg        active_p4;
 
-	generate if (MAX_PIPELINED) begin
+	generate if (EXTRA_FFS) begin
 		always @(posedge clk) begin
 			if (active_p3) begin
 				rd_p4           <= rd_p3;

--- a/picorv32.v
+++ b/picorv32.v
@@ -1917,7 +1917,7 @@ module picorv32_pcpi_mul #(
 endmodule
 
 module picorv32_pcpi_fast_mul #(
-	parameter MAX_PIPELINED = 1
+	parameter MAX_PIPELINED = 0
 	) (
 	input clk, resetn,
 

--- a/picorv32.v
+++ b/picorv32.v
@@ -1917,7 +1917,8 @@ module picorv32_pcpi_mul #(
 endmodule
 
 module picorv32_pcpi_fast_mul #(
-	parameter EXTRA_FFS = 0
+	parameter EXTRA_INSN_FFS = 0,
+	parameter EXTRA_MUL_FFS = 0
 	) (
 	input clk, resetn,
 
@@ -1973,7 +1974,7 @@ module picorv32_pcpi_fast_mul #(
 	reg [31:0] pcpi_rs1_p1;
 	reg [31:0] pcpi_rs2_p1;
 
-	generate if (EXTRA_FFS) begin
+	generate if (EXTRA_INSN_FFS) begin
     
 		always @(posedge clk) begin
 			if (active_p0) begin
@@ -2039,7 +2040,7 @@ module picorv32_pcpi_fast_mul #(
 	reg        shift_out_p4;
 	reg        active_p4;
 
-	generate if (EXTRA_FFS) begin
+	generate if (EXTRA_MUL_FFS) begin
 		always @(posedge clk) begin
 			if (active_p3) begin
 				rd_p4           <= rd_p3;

--- a/picorv32.v
+++ b/picorv32.v
@@ -1931,9 +1931,9 @@ module picorv32_pcpi_fast_mul #(
 	output            pcpi_ready
 );
 
-	reg pcpi_valid_q;
+	reg pcpi_valid_p1;
 	always @(posedge clk) begin
-		pcpi_valid_q <= pcpi_valid;
+		pcpi_valid_p1 <= pcpi_valid;
 	end
 
 	reg active_p0;
@@ -1946,7 +1946,7 @@ module picorv32_pcpi_fast_mul #(
 		instr_mulhu_p0  = 0;
 		active_p0       = 0;
 
-		if (resetn && pcpi_valid && !pcpi_valid_q && pcpi_insn[6:0] == 7'b0110011 && pcpi_insn[31:25] == 7'b0000001) begin
+		if (resetn && pcpi_valid && !pcpi_valid_p1 && pcpi_insn[6:0] == 7'b0110011 && pcpi_insn[31:25] == 7'b0000001) begin
 			case (pcpi_insn[14:12])
 				3'b000: instr_mul_p0    = 1;
 				3'b001: instr_mulh_p0   = 1;
@@ -1958,7 +1958,7 @@ module picorv32_pcpi_fast_mul #(
 		end
 	end
     
-	wire instr_any_mul_p0    = |{instr_mul_p0, instr_mulh_p0, instr_mulhsu_p0, instr_mulhu_p0};
+	wire instr_any_mul_p0    = |{instr_mulh_p0, instr_mulhsu_p0, instr_mulhu_p0, instr_mul_p0};
 	wire instr_any_mulh_p0   = |{instr_mulh_p0, instr_mulhsu_p0, instr_mulhu_p0};
 	wire instr_rs1_signed_p0 = |{instr_mulh_p0, instr_mulhsu_p0};
 	wire instr_rs2_signed_p0 = |{instr_mulh_p0};
@@ -2019,7 +2019,7 @@ module picorv32_pcpi_fast_mul #(
 			else
 				rs2_p2 <= $unsigned(pcpi_rs2_p1);
 
-		    shift_out_p2 <= instr_any_mulh_p1;
+			shift_out_p2 <= instr_any_mulh_p1;
 		end
 
         active_p2 <= resetn && active_p1;

--- a/picorv32.v
+++ b/picorv32.v
@@ -981,9 +981,9 @@ module picorv32 #(
 			instr_and   <= is_alu_reg_reg && mem_rdata_q[14:12] == 3'b111 && mem_rdata_q[31:25] == 7'b0000000;
 
 			instr_rdcycle  <= ((mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11000000000000000010) ||
-					   (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11000000000100000010)) && ENABLE_COUNTERS;
+			                   (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11000000000100000010)) && ENABLE_COUNTERS;
 			instr_rdcycleh <= ((mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11001000000000000010) ||
-					   (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11001000000100000010)) && ENABLE_COUNTERS && ENABLE_COUNTERS64;
+			                   (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11001000000100000010)) && ENABLE_COUNTERS && ENABLE_COUNTERS64;
 			instr_rdinstr  <=  (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11000000001000000010) && ENABLE_COUNTERS;
 			instr_rdinstrh <=  (mem_rdata_q[6:0] == 7'b1110011 && mem_rdata_q[31:12] == 'b11001000001000000010) && ENABLE_COUNTERS && ENABLE_COUNTERS64;
 


### PR DESCRIPTION
With the current FAST_MUL, the multiplier is always in the critical path on the Altera devices that I've tested. 

On Arria 10 and later, the current design reaches 350MHz. With this patch, clocks go up to 385MHz. and the multiplier is completely removed from the critical path.

On devices with current generation DSPs, it costs ~100 extra FFs. 

I have disabled the pipeline stages by default, because on older devices like Cyclone 4 it doesn't improve timing at all and adds a lot of new FFs, since there are no double input register banks inside the multipliers.

I'm not a big fan of the current name "max_pipelined". I currently also don't bring this parameter to the toplevel, since the improvement may be too much of a corner case? For me. having the extra slack is helpful... Please advise.

Dhrystone performance impact is on the order of 0.2%. 