### PR TITLE
Add STACKADDR parameter to picorv32_axi module

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -2311,7 +2311,8 @@ module picorv32_axi #(
 	parameter [31:0] MASKED_IRQ = 32'h 0000_0000,
 	parameter [31:0] LATCHED_IRQ = 32'h ffff_ffff,
 	parameter [31:0] PROGADDR_RESET = 32'h 0000_0000,
-	parameter [31:0] PROGADDR_IRQ = 32'h 0000_0010
+	parameter [31:0] PROGADDR_IRQ = 32'h 0000_0010,
+	parameter [31:0] STACKADDR = 32'h 0000_0fff
 ) (
 	input clk, resetn,
 	output trap,
@@ -2419,7 +2420,8 @@ module picorv32_axi #(
 		.MASKED_IRQ          (MASKED_IRQ          ),
 		.LATCHED_IRQ         (LATCHED_IRQ         ),
 		.PROGADDR_RESET      (PROGADDR_RESET      ),
-		.PROGADDR_IRQ        (PROGADDR_IRQ        )
+		.PROGADDR_IRQ        (PROGADDR_IRQ        ),
+		.STACKADDR           (STACKADDR           )
 	) picorv32_core (
 		.clk      (clk   ),
 		.resetn   (resetn),


### PR DESCRIPTION
This version is used for the packaged Vivado IP version. I just added the STACKADDR parameter to the picorv32_axi module so that we can modify it using the GUI in Vivado.