### PR TITLE
Makefile: fix 'view' goal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ COMPRESSED_ISA = C
 test: testbench.vvp firmware/firmware.hex
 	vvp -N testbench.vvp
 
-testbench_vcd: testbench.vvp firmware/firmware.hex
+testbench.vcd: testbench.vvp firmware/firmware.hex
 	vvp -N $< +vcd +trace +noerror
 
-view: testbench_vcd
+view: testbench.vcd
 	gtkwave $< testbench.gtkw
 
 check: check-yices


### PR DESCRIPTION
This commit fixes this error:

  $ make view

  ...

  ALL TESTS PASSED.
  gtkwave testbench_vcd testbench.gtkw

  GTKWave Analyzer v3.3.78 (w)1999-2016 BSI

  Error opening  .vcd file 'testbench_vcd'.
  Why: No such file or directory
  Makefile:20: recipe for target 'view' failed
  make: *** [view] Error 255

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>