### PR TITLE
testbench_wb.v: unify verbose output with axi testbench

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -2610,13 +2610,14 @@ module picorv32_wb #(
 
 	// Trace Interface
 	output        trace_valid,
-	output [35:0] trace_data
+	output [35:0] trace_data,
+
+	output mem_instr
 );
 	wire        mem_valid;
 	wire [31:0] mem_addr;
 	wire [31:0] mem_wdata;
 	wire [ 3:0] mem_wstrb;
-	wire        mem_instr;
 	reg         mem_ready;
 	reg [31:0] mem_rdata;
 


### PR DESCRIPTION
Unification of testbench output makes it possible to use the diff
utility for comparing testbench instruction traces.

Alas the testbench and testbench_wb traces are differ
because of interrupts, e.g.

    picorv32$ make testbench_wb.vvp
    iverilog -o testbench_wb.vvp -DCOMPRESSED_ISA -DRISCV_FORMAL testbench_wb.v picorv32.v
    chmod -x testbench_wb.vvp
    picorv32$ make testbench.vvp
    iverilog -o testbench.vvp -DCOMPRESSED_ISA -DRISCV_FORMAL testbench.v picorv32.v
    chmod -x testbench.vvp
    picorv32$ vvp -N testbench_wb.vvp +verbose | head -n 856 > /tmp/testbench_wb.log
    picorv32$ vvp -N testbench.vvp +verbose | head -n 856 > /tmp/testbench.log
    picorv32$ diff -u /tmp/testbench.log /tmp/testbench_wb.log
    --- /tmp/testbench.log  2017-04-06 06:56:06.079804549 +0300
    +++ /tmp/testbench_wb.log       2017-04-06 06:55:58.763485130 +0300
    @@ -850,7 +850,7 @@
     RD: ADDR=000056a0 DATA=00000013 INSN
     RD: ADDR=000056a4 DATA=fff00113 INSN
     RD: ADDR=000056a8 DATA=00000013 INSN
    -RD: ADDR=000056ac DATA=14208463 INSN  <--- testbench: no interrupt
    -RD: ADDR=000056b0 DATA=00120213 INSN
    -RD: ADDR=000056b4 DATA=00200293 INSN
    -RD: ADDR=000056b8 DATA=fe5212e3 INSN
    +RD: ADDR=00000010 DATA=0200a10b INSN  <--- testbench_wb: interrupt
    +RD: ADDR=00000014 DATA=0201218b INSN
    +RD: ADDR=00000018 DATA=000000b7 INSN
    +RD: ADDR=0000001c DATA=16008093 INSN

Signed-off-by: Antony Pavlov <antonynpavlov@gmail.com>