### PR TITLE
Testbench wb fixes

### DIFF
--- a/testbench_wb.v
+++ b/testbench_wb.v
@@ -166,6 +166,25 @@ module picorv32_wrapper #(
 	end
 endmodule
 
+/* ISC License
+ *
+ * Verilog on-chip RAM with Wishbone interface
+ *
+ * Copyright (C) 2014, 2016 Olof Kindgren <olof.kindgren@gmail.com>
+ *
+ * Permission to use, copy, modify, and/or distribute this software for any
+ * purpose with or without fee is hereby granted, provided that the above
+ * copyright notice and this permission notice appear in all copies.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS" AND THE AUTHOR DISCLAIMS ALL WARRANTIES
+ * WITH REGARD TO THIS SOFTWARE INCLUDING ALL IMPLIED WARRANTIES OF
+ * MERCHANTABILITY AND FITNESS. IN NO EVENT SHALL THE AUTHOR BE LIABLE FOR
+ * ANY SPECIAL, DIRECT, INDIRECT, OR CONSEQUENTIAL DAMAGES OR ANY DAMAGES
+ * WHATSOEVER RESULTING FROM LOSS OF USE, DATA OR PROFITS, WHETHER IN AN
+ * ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
+ * OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
+ */
+
 module wb_ram #(
 	parameter depth = 256,
 	parameter memfile = "",

--- a/testbench_wb.v
+++ b/testbench_wb.v
@@ -87,7 +87,6 @@ module picorv32_wrapper #(
 
 	wb_ram #(
 		.depth (16384 * 4),
-		.memfile ("firmware/firmware.hex"),
 		.VERBOSE (VERBOSE)
 	) ram ( // Wishbone interface
 		.wb_clk_i(wb_clk),
@@ -138,6 +137,13 @@ module picorv32_wrapper #(
 		.wbm_we_o(wb_m2s_we),
 		.wbm_sel_o(wb_m2s_sel)
 	);
+
+	reg [1023:0] firmware_file;
+	initial begin
+		if (!$value$plusargs("firmware=%s", firmware_file))
+			firmware_file = "firmware/firmware.hex";
+		$readmemh(firmware_file, ram.mem);
+	end
 
 	integer cycle_counter;
 	always @(posedge wb_clk) begin


### PR DESCRIPTION
Load firmware in testbench_wb from plusarg instead of parameter to allow selection at runtime. Also add attribution for wb_ram module, originally from https://github.com/fusesoc/wb_ram