### PR TITLE
fix signed issue in vcs I-2014.03

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -636,7 +636,7 @@ module picorv32 #(
 	wire instr_trap;
 
 	reg [regindex_bits-1:0] decoded_rd, decoded_rs1, decoded_rs2;
-	reg [31:0] decoded_imm, decoded_imm_uj;
+	reg signed [31:0] decoded_imm, decoded_imm_uj;
 	reg decoder_trigger;
 	reg decoder_trigger_q;
 	reg decoder_pseudo_trigger;


### PR DESCRIPTION
hi, cliffordwolf, in vcs I-2014.03, jal instruction does't jump the the expected address
see https://github.com/cliffordwolf/picorv32/issues/33 for more detail

this modification test passed in iverilog