### PR TITLE
Small fixes to the IceStorm scripts

### DIFF
--- a/scripts/icestorm/Makefile
+++ b/scripts/icestorm/Makefile
@@ -4,7 +4,7 @@ TOOLCHAIN_PREFIX = riscv32-unknown-elf-
 all: example.bin
 
 firmware.elf: firmware.S firmware.c firmware.lds
-	$(TOOLCHAIN_PREFIX)gcc -Os -m32 -ffreestanding -nostdlib -o firmware.elf firmware.S firmware.c \
+	$(TOOLCHAIN_PREFIX)gcc -Os -ffreestanding -nostdlib -o firmware.elf firmware.S firmware.c \
 			--std=gnu99 -Wl,-Bstatic,-T,firmware.lds,-Map,firmware.map,--strip-debug -lgcc
 	chmod -x firmware.elf
 

--- a/scripts/icestorm/Makefile
+++ b/scripts/icestorm/Makefile
@@ -35,7 +35,7 @@ example_sim_vcd: example_tb.vvp
 	vvp -N example_tb.vvp +vcd
 
 synth_tb.vvp: example_tb.v synth.blif
-	iverilog -o synth_tb.vvp -s testbench synth.v example_tb.v /usr/local/share/yosys/ice40/cells_sim.v
+	iverilog -o synth_tb.vvp -s testbench synth.v example_tb.v `yosys-config --datdir/ice40/cells_sim.v`
 	chmod -x synth_tb.vvp
 
 synth_sim: synth_tb.vvp
@@ -48,7 +48,7 @@ route.v: example.asc
 	icebox_vlog -L -n top -sp example.pcf example.asc > route.v
 
 route_tb.vvp: example_tb.v route.v
-	iverilog -o route_tb.vvp -s testbench route.v example_tb.v /usr/local/share/yosys/ice40/cells_sim.v
+	iverilog -o route_tb.vvp -s testbench route.v example_tb.v `yosys-config --datdir/ice40/cells_sim.v`
 	chmod -x route_tb.vvp
 
 route_sim: route_tb.vvp

--- a/scripts/quartus/Makefile
+++ b/scripts/quartus/Makefile
@@ -37,7 +37,7 @@ sim_system: firmware.hex system_tb.v system.v ../../picorv32.v
 	./system_tb
 
 firmware.hex: firmware.S firmware.c firmware.lds
-	$(TOOLCHAIN_PREFIX)gcc -Os -m32 -ffreestanding -nostdlib -o firmware.elf firmware.S firmware.c \
+	$(TOOLCHAIN_PREFIX)gcc -Os -ffreestanding -nostdlib -o firmware.elf firmware.S firmware.c \
 		 --std=gnu99 -Wl,-Bstatic,-T,firmware.lds,-Map,firmware.map,--strip-debug -lgcc
 	$(TOOLCHAIN_PREFIX)objcopy -O binary firmware.elf firmware.bin
 	python3 ../../firmware/makehex.py firmware.bin 4096 > firmware.hex

--- a/scripts/vivado/Makefile
+++ b/scripts/vivado/Makefile
@@ -41,7 +41,7 @@ sim_system:
 	$(XELAB) -L unifast_ver -L unisims_ver -R system_tb glbl
 
 firmware.hex: firmware.S firmware.c firmware.lds
-	$(TOOLCHAIN_PREFIX)gcc -Os -m32 -ffreestanding -nostdlib -o firmware.elf firmware.S firmware.c \
+	$(TOOLCHAIN_PREFIX)gcc -Os -ffreestanding -nostdlib -o firmware.elf firmware.S firmware.c \
 		 --std=gnu99 -Wl,-Bstatic,-T,firmware.lds,-Map,firmware.map,--strip-debug -lgcc
 	$(TOOLCHAIN_PREFIX)objcopy -O binary firmware.elf firmware.bin
 	python3 ../../firmware/makehex.py firmware.bin 4096 > firmware.hex


### PR DESCRIPTION
Fixes deprecated usage of `-m32` for RISCV GCC, and hardcoded paths to `/usr/local` in favor of `yosys-config --datdir` (like `picosoc` does).