### PR TITLE
Verilator testbench and FuseSoC support

### DIFF
--- a/picorv32.core
+++ b/picorv32.core
@@ -1,0 +1,78 @@
+CAPI=2:
+name : ::picorv32:0-r1
+
+filesets:
+  rtl:
+    files: [picorv32.v]
+    file_type : verilogSource
+  tb:
+    files: [testbench.v]
+    file_type : verilogSource
+    depend:
+  tb_ez:
+    files: [testbench_ez.v]
+    file_type : verilogSource
+  tb_wb:
+    files: [testbench_wb.v]
+    file_type : verilogSource
+  tb_verilator:
+    files:
+      - testbench.cc : {file_type : cppSource}
+
+targets:
+  default:
+    filesets: [rtl]
+  lint:
+    filesets: [rtl]
+    default_tool : verilator
+    tools:
+      verilator:
+        mode : lint-only
+    toplevel : [picorv32_axi]
+  test:
+    default_tool: icarus
+    filesets: [rtl, tb, "tool_verilator? (tb_verilator)"]
+    parameters: [COMPRESSED_ISA, axi_test, firmware, noerror, trace, vcd, verbose]
+    toplevel:
+      - "tool_verilator?  (picorv32_wrapper)"
+      - "!tool_verilator? (testbench)"
+      
+    tools:
+      verilator :
+        cli_parser : fusesoc
+        mode : cc
+        verilator_options : [-Wno-fatal, --trace]
+  test_ez:
+    default_tool: icarus
+    filesets: [rtl, tb_ez]
+    parameters: [vcd]
+    toplevel: [testbench]
+  test_wb:
+    default_tool: icarus
+    filesets: [rtl, tb_wb]
+    parameters: [COMPRESSED_ISA, firmware, noerror, trace, vcd]
+    toplevel: [testbench]
+
+parameters:
+  COMPRESSED_ISA:
+    datatype  : str
+    default   : 1
+    paramtype : vlogdefine
+  axi_test:
+    datatype  :  bool
+    paramtype : plusarg
+  firmware:
+    datatype  :  file
+    paramtype : plusarg
+  noerror:
+    datatype  :  bool
+    paramtype : plusarg
+  trace:
+    datatype  : bool
+    paramtype : plusarg
+  vcd:
+    datatype  : bool
+    paramtype : plusarg
+  verbose:
+    datatype : bool
+    paramtype : plusarg

--- a/testbench.cc
+++ b/testbench.cc
@@ -1,0 +1,27 @@
+#include "Vpicorv32_wrapper.h"
+#include "verilated_vcd_c.h"
+
+int main(int argc, char **argv, char **env)
+{
+	Verilated::commandArgs(argc, argv);
+	Verilated::traceEverOn(true);
+	Vpicorv32_wrapper* top = new Vpicorv32_wrapper;
+
+	VerilatedVcdC* tfp = new VerilatedVcdC;
+	top->trace (tfp, 99);
+        tfp->open ("testbench.vcd");
+	top->clk = 0;
+	int t = 0;
+	while (!Verilated::gotFinish()) {
+		if (t > 200)
+			top->resetn = 1;
+		top->clk = !top->clk;
+		top->eval();
+		tfp->dump (t);
+		t += 5;
+	}
+	tfp->close();
+	delete top;
+	exit(0);
+}
+


### PR DESCRIPTION
First patch adds a verilator testbench. This is the testbench from scripts/csmith but with added VCD generation

Second patch adds FuseSoC support for running testbenches and an additional lint target

FuseSoC support can be tested by first creating a workspace directory and register picorv32 as a library by running

    fusesoc library add picorv32 https://github.com/cliffordwolf/picorv32

or, alternatively if the repo is already on disk and you want to use that instead, run

    fusesoc library add picorv32 /path/to/repo

To list all targets supported by the picorv32 core, run `fusesoc core-info picorv32`. To run the standard testbench, use `fusesoc run --target=test --tool=<tool> picorv32 --firmware=/path/to/firmware.hex` where `<tool>` can be any of icarus, isim, modelsim, rivierapro, verilator or xsim. *Note that simulation with isim fails for some reason*. If `--tool` is omitted, icarus will be used as the default tool. The standard testbench requires a firmware file to be loaded with the `--firmware` argument. To see all available compile- and runtime options for this target run `fusesoc run --target=test picorv32 --help`. The `test_ez` and `test_wb` target requires no firmware file and also has less available options.

To run the verilator linter use `fusesoc run --target=lint picorv32`
