### PR TITLE
add .data and .bss segments to picosoc

### DIFF
--- a/picosoc/sections.lds
+++ b/picosoc/sections.lds
@@ -1,6 +1,8 @@
 SECTIONS {
 	.memory : {
 		sram = 0;
+		*(.data);
+		*(.bss);
 		. = 0x100000;
 		start*(.text);
 		*(.text);


### PR DESCRIPTION
added .data and .bss segments to picosoc firmware linker script so that static variables may be used.  