### PR TITLE
Picosoc fusesoc

### DIFF
--- a/hx8kdemo.core
+++ b/hx8kdemo.core
@@ -1,0 +1,40 @@
+CAPI=2:
+
+name : ::hx8kdemo:0
+
+filesets:
+  hx8kdemo:
+    files: [picosoc/hx8kdemo.v]
+    file_type : verilogSource
+    depend : [picosoc]
+  hx8ksim:
+    files:
+      - picosoc/hx8kdemo_tb.v
+    file_type : verilogSource
+    depend : [spiflash]
+  modelsim_cells:
+    files: [picosoc/vlog_cells_sim.tcl : {file_type : tclSource}]
+
+  constraints:
+    files: [picosoc/hx8kdemo.pcf]
+    file_type : PCF
+
+targets:
+  synth:
+    default_tool : icestorm
+    filesets : [constraints, hx8kdemo]
+    tools:
+      icestorm:
+        arachne_pnr_options : [-d, 8k]
+    toplevel : [hx8kdemo]
+  sim:
+    default_tool : icarus
+    filesets : ["tool_modelsim? (modelsim_cells)", hx8kdemo, hx8ksim]
+    tools:
+      icarus:
+        iverilog_options:
+          ["`yosys-config --datdir/ice40/cells_sim.v`"]
+      xsim:
+        xelab_options:
+          [--relax, "--sourcelibfile `yosys-config --datdir/ice40/cells_sim.v`"]
+    toplevel : [testbench]

--- a/picosoc.core
+++ b/picosoc.core
@@ -1,0 +1,17 @@
+CAPI=2:
+
+name : ::picosoc:0
+
+filesets:
+  picosoc:
+    files:
+      - picosoc/simpleuart.v
+      - picosoc/spimemio.v
+      - picosoc/picosoc_regs.v
+      - picosoc/picosoc.v
+    file_type : verilogSource
+    depend : [picorv32]
+
+targets:
+  default:
+    filesets : [picosoc]

--- a/picosoc/Makefile
+++ b/picosoc/Makefile
@@ -7,10 +7,10 @@ hx8ksim: hx8kdemo_tb.vvp firmware.hex
 hx8ksynsim: hx8kdemo_syn_tb.vvp firmware.hex
 	vvp -N $<
 
-hx8kdemo.blif: hx8kdemo.v spimemio.v simpleuart.v picosoc.v ../picorv32.v
+hx8kdemo.blif: hx8kdemo.v spimemio.v simpleuart.v picosoc_regs.v picosoc.v ../picorv32.v
 	yosys -ql hx8kdemo.log -p 'synth_ice40 -top hx8kdemo -blif hx8kdemo.blif' $^
 
-hx8kdemo_tb.vvp: hx8kdemo_tb.v hx8kdemo.v spimemio.v simpleuart.v picosoc.v ../picorv32.v spiflash.v
+hx8kdemo_tb.vvp: hx8kdemo_tb.v hx8kdemo.v spimemio.v simpleuart.v picosoc_regs.v picosoc.v ../picorv32.v spiflash.v
 	iverilog -s testbench -o $@ $^ `yosys-config --datdir/ice40/cells_sim.v`
 
 hx8kdemo_syn_tb.vvp: hx8kdemo_tb.v hx8kdemo_syn.v spiflash.v
@@ -54,7 +54,7 @@ spiflash_tb.vvp: spiflash.v spiflash_tb.v
 
 # ---- ASIC Synthesis Tests ----
 
-cmos.log: spimemio.v simpleuart.v picosoc.v ../picorv32.v
+cmos.log: spimemio.v simpleuart.v picosoc_regs.v picosoc.v ../picorv32.v
 	yosys -l cmos.log -p 'synth -top picosoc; abc -g cmos2; opt -fast; stat' $^
 
 # ---- Clean ----

--- a/picosoc/README.md
+++ b/picosoc/README.md
@@ -25,16 +25,17 @@ Run `make test` to run the test bench (and create `testbench.vcd`).
 Run `make prog` to build the configuration bit-stream and firmware images
 and upload them to a connected iCE40-HX8K Breakout Board.
 
-| File                          | Description                                                     |
-| ----------------------------- | --------------------------------------------------------------- |
-| [picosoc.v](picosoc.v)        | Top-level PicoSoC Verilog module                                |
-| [spimemio.v](spimemio.v)      | Memory controller that interfaces to external SPI flash         |
-| [simpleuart.v](simpleuart.v)  | Simple UART core connected directly to SoC TX/RX lines          |
-| [start.s](start.s)            | Assembler source for firmware.hex/firmware.bin                  |
-| [firmware.c](firmware.c)      | C source for firmware.hex/firmware.bin                          |
-| [sections.lds](sections.lds)  | Linker script for firmware.hex/firmware.bin                     |
-| [hx8kdemo.v](hx8kdemo.v)      | FPGA-based example implementation on iCE40-HX8K Breakout Board  |
-| [hx8kdemo.pcf](hx8kdemo.pcf)  | Pin constraints for implementation on iCE40-HX8K Breakout Board |
+| File                             | Description                                                     |
+| -------------------------------- | --------------------------------------------------------------- |
+| [picosoc.v](picosoc.v)           | Top-level PicoSoC Verilog module                                |
+| [picosoc_regs.v](picosoc_regs.v) | Default register file implementation for picorv32               |
+| [spimemio.v](spimemio.v)         | Memory controller that interfaces to external SPI flash         |
+| [simpleuart.v](simpleuart.v)     | Simple UART core connected directly to SoC TX/RX lines          |
+| [start.s](start.s)               | Assembler source for firmware.hex/firmware.bin                  |
+| [firmware.c](firmware.c)         | C source for firmware.hex/firmware.bin                          |
+| [sections.lds](sections.lds)     | Linker script for firmware.hex/firmware.bin                     |
+| [hx8kdemo.v](hx8kdemo.v)         | FPGA-based example implementation on iCE40-HX8K Breakout Board  |
+| [hx8kdemo.pcf](hx8kdemo.pcf)     | Pin constraints for implementation on iCE40-HX8K Breakout Board |
 
 ### Memory map:
 

--- a/picosoc/picosoc.v
+++ b/picosoc/picosoc.v
@@ -17,12 +17,6 @@
  *
  */
 
-`ifdef PICORV32_V
-`error "picosoc.v must be read before picorv32.v!"
-`endif
-
-`define PICORV32_REGS picosoc_regs
-
 module picosoc (
 	input clk,
 	input resetn,
@@ -197,25 +191,7 @@ module picosoc (
 endmodule
 
 // Implementation note:
-// Replace the following two modules with wrappers for your SRAM cells.
-
-module picosoc_regs (
-	input clk, wen,
-	input [5:0] waddr,
-	input [5:0] raddr1,
-	input [5:0] raddr2,
-	input [31:0] wdata,
-	output [31:0] rdata1,
-	output [31:0] rdata2
-);
-	reg [31:0] regs [0:31];
-
-	always @(posedge clk)
-		if (wen) regs[waddr[4:0]] <= wdata;
-
-	assign rdata1 = regs[raddr1[4:0]];
-	assign rdata2 = regs[raddr2[4:0]];
-endmodule
+// Replace the following module (and picosoc_regs.v) with wrappers for your SRAM cells.
 
 module picosoc_mem #(
 	parameter integer WORDS = 256

--- a/picosoc/picosoc_regs.v
+++ b/picosoc/picosoc_regs.v
@@ -1,0 +1,19 @@
+`define PICORV32_REGS picosoc_regs
+
+module picosoc_regs (
+	input clk, wen,
+	input [5:0] waddr,
+	input [5:0] raddr1,
+	input [5:0] raddr2,
+	input [31:0] wdata,
+	output [31:0] rdata1,
+	output [31:0] rdata2
+);
+	reg [31:0] regs [0:31];
+
+	always @(posedge clk)
+		if (wen) regs[waddr[4:0]] <= wdata;
+
+	assign rdata1 = regs[raddr1[4:0]];
+	assign rdata2 = regs[raddr2[4:0]];
+endmodule

--- a/picosoc/spiflash.v
+++ b/picosoc/spiflash.v
@@ -98,8 +98,11 @@ module spiflash (
 	// 16 MB (128Mb) Flash
 	reg [7:0] memory [0:16*1024*1024-1];
 
+	reg [1023:0] firmware_file;
 	initial begin
-		$readmemh("firmware.hex", memory);
+		if (!$value$plusargs("firmware=%s", firmware_file))
+			firmware_file = "firmware.hex";
+		$readmemh(firmware_file, memory);
 	end
 
 	task spi_action;

--- a/picosoc/vlog_cells_sim.tcl
+++ b/picosoc/vlog_cells_sim.tcl
@@ -1,0 +1,1 @@
+vlog -mixedansiports [yosys-config --datdir/ice40/cells_sim.v]

--- a/spiflash.core
+++ b/spiflash.core
@@ -1,0 +1,24 @@
+CAPI=2:
+
+name : ::spiflash:0
+
+filesets:
+  model:
+    files : [picosoc/spiflash.v]
+    file_type : verilogSource
+  tb:
+    files : [picosoc/spiflash_tb.v]
+    file_type : verilogSource
+
+targets:
+  default:
+    default_tool : icarus
+    filesets : [model, "is_toplevel? (tb)"]
+    parameters : [firmware]
+    toplevel : [testbench]
+
+parameters :
+  firmware:
+    datatype    : file
+    description : Initial SPI Flash contents (in verilog hex format)
+    paramtype   : plusarg


### PR DESCRIPTION
This adds three FuseSoC .core files for the spiflash model, the generic picosoc code and the hx8kdemo implementation of picosoc. The intention is to make it easier to reuse the generic parts of picosoc and the spiflash code in other projects.

The most controversial change here is splitting out picosoc_regs into a separate file. This was done both to not having to compile picosoc.v before picorv32.v as well as making it easier to source other implementations of picosoc_regs without having to edit any code