### PR TITLE
Rewrite PICORV32_REGS mechanism

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -45,11 +45,6 @@
 // uncomment this for register file in extra module
 // `define PICORV32_REGS picorv32_regs
 
-// this macro can be used to check if the verilog files in your
-// design are read in the correct order.
-`define PICORV32_V
-
-
 /***************************************************************
  * picorv32
  ***************************************************************/

--- a/picosoc/Makefile
+++ b/picosoc/Makefile
@@ -7,10 +7,10 @@ hx8ksim: hx8kdemo_tb.vvp firmware.hex
 hx8ksynsim: hx8kdemo_syn_tb.vvp firmware.hex
 	vvp -N $<
 
-hx8kdemo.blif: hx8kdemo.v spimemio.v simpleuart.v picosoc.v ../picorv32.v
+hx8kdemo.blif: hx8kdemo.v spimemio.v simpleuart.v picosoc_regs.v ../picorv32.v picosoc.v
 	yosys -ql hx8kdemo.log -p 'synth_ice40 -top hx8kdemo -blif hx8kdemo.blif' $^
 
-hx8kdemo_tb.vvp: hx8kdemo_tb.v hx8kdemo.v spimemio.v simpleuart.v picosoc.v ../picorv32.v spiflash.v
+hx8kdemo_tb.vvp: hx8kdemo_tb.v hx8kdemo.v spimemio.v simpleuart.v picosoc_regs.v ../picorv32.v picosoc.v spiflash.v
 	iverilog -s testbench -o $@ $^ `yosys-config --datdir/ice40/cells_sim.v`
 
 hx8kdemo_syn_tb.vvp: hx8kdemo_tb.v hx8kdemo_syn.v spiflash.v

--- a/picosoc/README.md
+++ b/picosoc/README.md
@@ -25,16 +25,17 @@ Run `make test` to run the test bench (and create `testbench.vcd`).
 Run `make prog` to build the configuration bit-stream and firmware images
 and upload them to a connected iCE40-HX8K Breakout Board.
 
-| File                          | Description                                                     |
-| ----------------------------- | --------------------------------------------------------------- |
-| [picosoc.v](picosoc.v)        | Top-level PicoSoC Verilog module                                |
-| [spimemio.v](spimemio.v)      | Memory controller that interfaces to external SPI flash         |
-| [simpleuart.v](simpleuart.v)  | Simple UART core connected directly to SoC TX/RX lines          |
-| [start.s](start.s)            | Assembler source for firmware.hex/firmware.bin                  |
-| [firmware.c](firmware.c)      | C source for firmware.hex/firmware.bin                          |
-| [sections.lds](sections.lds)  | Linker script for firmware.hex/firmware.bin                     |
-| [hx8kdemo.v](hx8kdemo.v)      | FPGA-based example implementation on iCE40-HX8K Breakout Board  |
-| [hx8kdemo.pcf](hx8kdemo.pcf)  | Pin constraints for implementation on iCE40-HX8K Breakout Board |
+| File                             | Description                                                     |
+| -------------------------------- | --------------------------------------------------------------- |
+| [picosoc.v](picosoc.v)           | Top-level PicoSoC Verilog module                                |
+| [picosoc_regs.v](picosoc_regs.v) | Default register file implementation for picorv32               |
+| [spimemio.v](spimemio.v)         | Memory controller that interfaces to external SPI flash         |
+| [simpleuart.v](simpleuart.v)     | Simple UART core connected directly to SoC TX/RX lines          |
+| [start.s](start.s)               | Assembler source for firmware.hex/firmware.bin                  |
+| [firmware.c](firmware.c)         | C source for firmware.hex/firmware.bin                          |
+| [sections.lds](sections.lds)     | Linker script for firmware.hex/firmware.bin                     |
+| [hx8kdemo.v](hx8kdemo.v)         | FPGA-based example implementation on iCE40-HX8K Breakout Board  |
+| [hx8kdemo.pcf](hx8kdemo.pcf)     | Pin constraints for implementation on iCE40-HX8K Breakout Board |
 
 ### Memory map:
 

--- a/picosoc/picosoc.v
+++ b/picosoc/picosoc.v
@@ -17,11 +17,12 @@
  *
  */
 
-`ifdef PICORV32_V
-`error "picosoc.v must be read before picorv32.v!"
+//Implementation note:
+//`define PICORV32_REGS to the name of the module implementing the register file,
+// e.g. your SRAM cell wrappers, or set to picorv32_regs to use the picorv32-internal implementation.
+`ifndef PICORV32_REGS
+`error "PICORV32_REGS must be defined to the module name of a valid implementation of the cpuregs module!"
 `endif
-
-`define PICORV32_REGS picosoc_regs
 
 module picosoc (
 	input clk,
@@ -197,25 +198,7 @@ module picosoc (
 endmodule
 
 // Implementation note:
-// Replace the following two modules with wrappers for your SRAM cells.
-
-module picosoc_regs (
-	input clk, wen,
-	input [5:0] waddr,
-	input [5:0] raddr1,
-	input [5:0] raddr2,
-	input [31:0] wdata,
-	output [31:0] rdata1,
-	output [31:0] rdata2
-);
-	reg [31:0] regs [0:31];
-
-	always @(posedge clk)
-		if (wen) regs[waddr[4:0]] <= wdata;
-
-	assign rdata1 = regs[raddr1[4:0]];
-	assign rdata2 = regs[raddr2[4:0]];
-endmodule
+// Replace the following module with wrappers for your SRAM cells.
 
 module picosoc_mem #(
 	parameter integer WORDS = 256

--- a/picosoc/picosoc_regs.v
+++ b/picosoc/picosoc_regs.v
@@ -1,0 +1,21 @@
+`ifndef PICORV32_REGS
+`define PICORV32_REGS picosoc_regs
+`endif
+
+module picosoc_regs (
+	input clk, wen,
+	input [5:0] waddr,
+	input [5:0] raddr1,
+	input [5:0] raddr2,
+	input [31:0] wdata,
+	output [31:0] rdata1,
+	output [31:0] rdata2
+);
+	reg [31:0] regs [0:31];
+
+	always @(posedge clk)
+		if (wen) regs[waddr[4:0]] <= wdata;
+
+	assign rdata1 = regs[raddr1[4:0]];
+	assign rdata2 = regs[raddr2[4:0]];
+endmodule


### PR DESCRIPTION
Previously, picosoc.v needed to be sourced before picorv32.v to
ensure that the PICORV32 `define (used to select implementation for
the register file) was set to picosoc_regs

By splitting out picosoc_regs into a separate module, this can now
be sourced before picorv32 to achieve the same effect. PICORV32_REGS
can also be set externally (e.g. -DPICORV32_REGS=picosoc_regs for
Icarus, or verilog_defines -DPICORV32_REGS=picosoc_regs for yosys)
to allow the module implementing cpuregs to be sourced after picorv32

8<-----------------------------

Some notes:

This does not touch picosoc_mem as I reckon it would make more sense to do in a separate PR

The `error keyword did not seem to work in either yosys or Icarus, but I kept it anyway