### PR TITLE
Bypass picosoc compile order check if PICORV32_REGS is defined.

### DIFF
--- a/picosoc/picosoc.v
+++ b/picosoc/picosoc.v
@@ -17,11 +17,13 @@
  *
  */
 
+`ifndef PICORV32_REGS
 `ifdef PICORV32_V
 `error "picosoc.v must be read before picorv32.v!"
 `endif
 
 `define PICORV32_REGS picosoc_regs
+`endif
 
 module picosoc (
 	input clk,


### PR DESCRIPTION
Previously, picosoc.v needed to be sourced before picorv32.v to
ensure that the PICORV32_REGS `define (used to select implementation
for the register file) was set to picosoc_regs

This allows for overriding PICORV32_REGS, e.g. by setting it
externally in the EDA tool invocation. In this case, the compile
order between picorv32.v and picosoc.v is not important.

Note: This change will break the safety check if PICORV32_REGS
is defined between sourcing picorv32.v and picosoc.v

tool invocation.