### PR TITLE
Picosoc fusesoc v2

### DIFF
--- a/picosoc/hx8kdemo.core
+++ b/picosoc/hx8kdemo.core
@@ -1,0 +1,35 @@
+CAPI=2:
+
+name : ::hx8kdemo:0
+
+filesets:
+  hx8kdemo:
+    files: [hx8kdemo.v]
+    file_type : verilogSource
+    depend : [picosoc]
+  hx8ksim:
+    files:
+      - hx8kdemo_tb.v
+    file_type : verilogSource
+    depend : [spiflash, "yosys:techlibs:ice40"]
+
+  constraints:
+    files: [hx8kdemo.pcf]
+    file_type : PCF
+
+targets:
+  synth:
+    default_tool : icestorm
+    filesets : [constraints, hx8kdemo]
+    tools:
+      icestorm:
+        arachne_pnr_options : [-d, 8k]
+    toplevel : [hx8kdemo]
+  sim:
+    default_tool : icarus
+    filesets : [hx8kdemo, hx8ksim]
+    tools:
+      xsim:
+        xelab_options : [--timescale, 1ns/1ps]
+
+    toplevel : [testbench]

--- a/picosoc/picosoc.core
+++ b/picosoc/picosoc.core
@@ -1,0 +1,23 @@
+CAPI=2:
+
+name : ::picosoc:0
+
+filesets:
+  picosoc:
+    files:
+      - simpleuart.v
+      - spimemio.v
+      - picosoc.v
+    file_type : verilogSource
+    depend : [picorv32]
+
+targets:
+  default:
+    filesets : [picosoc]
+    parameters : [PICORV32_REGS]
+
+parameters:
+  PICORV32_REGS:
+    datatype : str
+    default  : picosoc_regs
+    paramtype : vlogdefine

--- a/picosoc/spiflash.core
+++ b/picosoc/spiflash.core
@@ -1,0 +1,24 @@
+CAPI=2:
+
+name : ::spiflash:0
+
+filesets:
+  model:
+    files : [spiflash.v]
+    file_type : verilogSource
+  tb:
+    files : [spiflash_tb.v]
+    file_type : verilogSource
+
+targets:
+  default:
+    default_tool : icarus
+    filesets : [model, "is_toplevel? (tb)"]
+    parameters : [firmware]
+    toplevel : [testbench]
+
+parameters :
+  firmware:
+    datatype    : file
+    description : Initial SPI Flash contents (in verilog hex format)
+    paramtype   : plusarg


### PR DESCRIPTION
Updated version of an old PR. The changes from the previous version is that the .core files now live in the picosoc directory as FuseSoC allows finding cores in subdirectories of other cores since version 1.8.3

Please note that due to a bug found after the 1.8.3 release which requires to specify `--target=default` in the cases where no explicit target was supplied on the command-line. This has been fixed in FuseSoC git master already but is not in a released version yet