### PR TITLE
Fix picorv32.core to include firmware.hex location in target testbench_wb

### DIFF
--- a/picorv32.core
+++ b/picorv32.core
@@ -38,7 +38,7 @@ targets:
     toplevel:
       - "tool_verilator?  (picorv32_wrapper)"
       - "!tool_verilator? (testbench)"
-      
+
     tools:
       verilator :
         cli_parser : fusesoc

--- a/picorv32.core
+++ b/picorv32.core
@@ -13,7 +13,9 @@ filesets:
     files: [testbench_ez.v]
     file_type : verilogSource
   tb_wb:
-    files: [testbench_wb.v]
+    files:
+        - testbench_wb.v
+        - firmware/firmware.hex: {file_type: user, copyto: firmware/firmware.hex}
     file_type : verilogSource
   tb_verilator:
     files:


### PR DESCRIPTION
The picorv32.core had a missing file in target testbench_wb, so command:

`fusesoc run --target=test_wb picorv32`

failed to run with the error: 
```
ERROR: ../src/picorv32_0-r1/testbench_wb.v:145: $readmemh: Unable to open firmware/firmware.hex for reading.
```

This fixes that to include the location of the firmware.hex file