### PR TITLE
Mul: use different operation for ALTOP

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -2296,7 +2296,11 @@ module picorv32_pcpi_fast_mul #(
 			rs2_q <= rs2;
 		end
 		if (!MUL_CLKGATE || active[1]) begin
+`ifdef RISCV_FORMAL_ALTOPS
+			rd <= $signed(EXTRA_MUL_FFS ? {rs1_q, rs1_q} : {rs1, rs1}) + $signed(EXTRA_MUL_FFS ? {rs2_q, rs2_q} : {rs2, rs2});
+`else
 			rd <= $signed(EXTRA_MUL_FFS ? rs1_q : rs1) * $signed(EXTRA_MUL_FFS ? rs2_q : rs2);
+`endif
 		end
 		if (!MUL_CLKGATE || active[2]) begin
 			rd_q <= rd;
@@ -2329,15 +2333,7 @@ module picorv32_pcpi_fast_mul #(
 	assign pcpi_wr = active[EXTRA_MUL_FFS ? 3 : 1];
 	assign pcpi_wait = 0;
 	assign pcpi_ready = active[EXTRA_MUL_FFS ? 3 : 1];
-`ifdef RISCV_FORMAL_ALTOPS
-	assign pcpi_rd =
-			instr_mul    ? (pcpi_rs1 + pcpi_rs2) ^ 32'h5876063e :
-			instr_mulh   ? (pcpi_rs1 + pcpi_rs2) ^ 32'hf6583fb7 :
-			instr_mulhsu ? (pcpi_rs1 - pcpi_rs2) ^ 32'hecfbe137 :
-			instr_mulhu  ? (pcpi_rs1 + pcpi_rs2) ^ 32'h949ce5e8 : 1'bx;
-`else
 	assign pcpi_rd = shift_out ? (EXTRA_MUL_FFS ? rd_q : rd) >> 32 : (EXTRA_MUL_FFS ? rd_q : rd);
-`endif
 endmodule
 
 


### PR DESCRIPTION
The current MUL ALTOP doesn't use the rs1, rs2, rd, and shift signals to calculate pcpi_rd, but bypassed them completely and uses pcpi_rs1 and pcpi_rs2 instead.

I believe that weakens the strength of the formal proof considerably?

With this PR, I only replace the multiply operations by an addition that covers all the bits, but leave everything else the same.

This way, all signals are covered and there is no need for the magic numbers.

Disclaimer: I'm still very green when it comes to this kind of formal stuff, so I may be missing something fundamental.