### PR TITLE
Add waveform generation for cocotb

### DIFF
--- a/picorv32.v
+++ b/picorv32.v
@@ -2094,6 +2094,13 @@ module picorv32 #(
 		end
 	end
 `endif
+`ifdef COCOTB_SIM
+	initial begin
+  		$dumpfile ("waveform.vcd");
+		$dumpvars (0,picorv32);
+		#1;
+	end
+`endif
 endmodule
 
 // This is a simple example implementation of PICORV32_REGS.


### PR DESCRIPTION
Generate waveform of all signals. Only enabled when `COCOTB_SIM` is set. cocotb uses VPI and directly instantiates this module directly. To avoid another testbench, the waveform is generated on this level.