### PR TITLE
Update vivado scripts

### DIFF
--- a/scripts/vivado/Makefile
+++ b/scripts/vivado/Makefile
@@ -1,5 +1,5 @@
 
-VIVADO_BASE = /opt/Xilinx/Vivado/2017.3
+VIVADO_BASE = /opt/Xilinx/Vivado/2018.2
 VIVADO = $(VIVADO_BASE)/bin/vivado
 XVLOG = $(VIVADO_BASE)/bin/xvlog
 XELAB = $(VIVADO_BASE)/bin/xelab

--- a/scripts/vivado/Makefile
+++ b/scripts/vivado/Makefile
@@ -4,7 +4,7 @@ VIVADO = $(VIVADO_BASE)/bin/vivado
 XVLOG = $(VIVADO_BASE)/bin/xvlog
 XELAB = $(VIVADO_BASE)/bin/xelab
 GLBL = $(VIVADO_BASE)/data/verilog/src/glbl.v
-TOOLCHAIN_PREFIX = riscv64-unknown-elf-
+TOOLCHAIN_PREFIX = riscv32-unknown-elf-
 
 export VIVADO
 


### PR DESCRIPTION
This updates the Vivado scripts folder
 - Update to use the 32 bit toolchain instead of the 64 bit one.
 - Use current Vivado version(2018.2).