### PR TITLE
fix firmware/sections.lds section size alignment on 4 bytes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,14 @@
+RISCV_PATH = /opt/riscv32i/bin
 
 RISCV_GNU_TOOLCHAIN_GIT_REVISION = 411d134
-RISCV_GNU_TOOLCHAIN_INSTALL_PREFIX = /opt/riscv32
+RISCV_GNU_TOOLCHAIN_INSTALL_PREFIX = $(RISCV_PATH)
 
 SHELL = bash
 TEST_OBJS = $(addsuffix .o,$(basename $(wildcard tests/*.S)))
 FIRMWARE_OBJS = firmware/start.o firmware/irq.o firmware/print.o firmware/sieve.o firmware/multest.o firmware/stats.o
 GCC_WARNS  = -Werror -Wall -Wextra -Wshadow -Wundef -Wpointer-arith -Wcast-qual -Wcast-align -Wwrite-strings
 GCC_WARNS += -Wredundant-decls -Wstrict-prototypes -Wmissing-prototypes -pedantic # -Wconversion
-TOOLCHAIN_PREFIX = $(RISCV_GNU_TOOLCHAIN_INSTALL_PREFIX)i/bin/riscv32-unknown-elf-
+TOOLCHAIN_PREFIX = $(RISCV_GNU_TOOLCHAIN_INSTALL_PREFIX)/riscv32-unknown-elf-
 COMPRESSED_ISA = C
 
 # Add things like "export http_proxy=... https_proxy=..." here

--- a/firmware/sections.lds
+++ b/firmware/sections.lds
@@ -20,5 +20,6 @@ SECTIONS {
 		*(.text);
 		*(*);
 		end = .;
+		. = ALIGN(4);
 	} > mem
 }


### PR DESCRIPTION
My freshly build toolchain fails to create a 4 bytes size aligned section.
The fix should be either in the firmware/sections.lds, or in the python script to automatically padding when not aligned with 4 bytes in size. Here it took the first approach.

Also modified slightly in Makefile how toolchain prefix is specified ... to allow easier adaptation by users.
For example, the installed riscv toolchain might not be called /opt/riscv32i, but rather /opt/riscv32/rv32i_ilp32, which requires two lines of modification ... Default path still preserved here.

A better implementation should have automatically detected if riscv gcc is already in search path, if not go and take env variable RISCV_PATH, and finally fallback to the Makefile default version ... but I really cannot write such complicated shell script, probably come up with a python implementation later.

Previous failure:
```
/opt/riscv/rv32i_ilp32/bin/riscv32-unknown-elf-objcopy -O binary firmware/firmware.elf firmware/firmware.bin
chmod -x firmware/firmware.bin
python3 firmware/makehex.py firmware/firmware.bin 16384 > firmware/firmware.hex
Traceback (most recent call last):
  File "firmware/makehex.py", line 23, in <module>
    assert len(bindata) % 4 == 0
AssertionError
Makefile:95: recipe for target 'firmware/firmware.hex' failed
make: *** [firmware/firmware.hex] Error 1
```