### PR TITLE
added CROSS prefix and CFLAGS to the picsoc/Makefile

### DIFF
--- a/picosoc/Makefile
+++ b/picosoc/Makefile
@@ -1,4 +1,7 @@
 
+CROSS=riscv32-unknown-elf-
+CFLAGS=
+
 # ---- iCE40 HX8K Breakout Board ----
 
 hx8ksim: hx8kdemo_tb.vvp hx8kdemo_fw.hex
@@ -34,16 +37,16 @@ hx8kprog_fw: hx8kdemo_fw.bin
 	iceprog -o 1M hx8kdemo_fw.bin
 
 hx8kdemo_sections.lds: sections.lds
-	riscv32-unknown-elf-cpp -P -DHX8KDEMO -o $@ $^
+	$(CROSS)cpp -P -DHX8KDEMO -o $@ $^
 
 hx8kdemo_fw.elf: hx8kdemo_sections.lds start.s firmware.c
-	riscv32-unknown-elf-gcc -DHX8KDEMO -march=rv32imc -Wl,-Bstatic,-T,hx8kdemo_sections.lds,--strip-debug -ffreestanding -nostdlib -o hx8kdemo_fw.elf start.s firmware.c
+	$(CROSS)gcc $(CFLAGS) -DHX8KDEMO -march=rv32imc -Wl,-Bstatic,-T,hx8kdemo_sections.lds,--strip-debug -ffreestanding -nostdlib -o hx8kdemo_fw.elf start.s firmware.c
 
 hx8kdemo_fw.hex: hx8kdemo_fw.elf
-	riscv32-unknown-elf-objcopy -O verilog hx8kdemo_fw.elf hx8kdemo_fw.hex
+	$(CROSS)objcopy -O verilog hx8kdemo_fw.elf hx8kdemo_fw.hex
 
 hx8kdemo_fw.bin: hx8kdemo_fw.elf
-	riscv32-unknown-elf-objcopy -O binary hx8kdemo_fw.elf hx8kdemo_fw.bin
+	$(CROSS)objcopy -O binary hx8kdemo_fw.elf hx8kdemo_fw.bin
 
 # ---- iCE40 IceBreaker Board ----
 
@@ -80,16 +83,16 @@ icebprog_fw: icebreaker_fw.bin
 	iceprog -o 1M icebreaker_fw.bin
 
 icebreaker_sections.lds: sections.lds
-	riscv32-unknown-elf-cpp -P -DICEBREAKER -o $@ $^
+	$(CROSS)cpp -P -DICEBREAKER -o $@ $^
 
 icebreaker_fw.elf: icebreaker_sections.lds start.s firmware.c
-	riscv32-unknown-elf-gcc -DICEBREAKER -march=rv32ic -Wl,-Bstatic,-T,icebreaker_sections.lds,--strip-debug -ffreestanding -nostdlib -o icebreaker_fw.elf start.s firmware.c
+	$(CROSS)gcc $(CFLAGS) -DICEBREAKER -march=rv32ic -Wl,-Bstatic,-T,icebreaker_sections.lds,--strip-debug -ffreestanding -nostdlib -o icebreaker_fw.elf start.s firmware.c
 
 icebreaker_fw.hex: icebreaker_fw.elf
-	riscv32-unknown-elf-objcopy -O verilog icebreaker_fw.elf icebreaker_fw.hex
+	$(CROSS)objcopy -O verilog icebreaker_fw.elf icebreaker_fw.hex
 
 icebreaker_fw.bin: icebreaker_fw.elf
-	riscv32-unknown-elf-objcopy -O binary icebreaker_fw.elf icebreaker_fw.bin
+	$(CROSS)objcopy -O binary icebreaker_fw.elf icebreaker_fw.bin
 
 # ---- Testbench for SPI Flash Model ----
 


### PR DESCRIPTION
so one can run it with other toolchains, e.g.
CROSS=riscv64-t2-linux-gnu- CFLAGS=-mabi=ilp32, too