### PR TITLE
spimemio documentation: read latency reset value

### DIFF
--- a/picosoc/README.md
+++ b/picosoc/README.md
@@ -75,7 +75,7 @@ mapped to the low byte of the 32 bit word at address 0x03000000.
 |     22 | DDR Enable bit (reset=0)                                  |
 |     21 | QSPI Enable bit (reset=0)                                 |
 |     20 | CRM Enable bit (reset=0)                                  |
-|  19:16 | Read latency (dummy) cycles (reset=0)                     |
+|  19:16 | Read latency (dummy) cycles (reset=8)                     |
 |  15:12 | Reserved (read 0)                                         |
 |   11:8 | IO Output enable bits in bit bang mode                    |
 |    7:6 | Reserved (read 0)                                         |


### PR DESCRIPTION
According to https://github.com/cliffordwolf/picorv32/blob/c06ba38113b98b4996aed6d523667444a5d83bf6/picosoc/spimemio.v#L111 the reset value for `Read latency (dummy) cycles` is 8 cycles, not 0.