### PR TITLE
Workarround: Disable cmd_memtest() when starting firmware.

### DIFF
--- a/picosoc/firmware.c
+++ b/picosoc/firmware.c
@@ -688,7 +688,7 @@ void main()
 	print(" KiB\n");
 	print("\n");
 
-	cmd_memtest();
+	//cmd_memtest(); // test overwrites bss and data memory
 	print("\n");
 
 	cmd_print_spi_state();


### PR DESCRIPTION
It destroys bss and data section memory.
You are not able to use static or global vars in firmware.c.