### PR TITLE
Insert delay after release power-down SPI flash command

### DIFF
--- a/picosoc/spimemio.v
+++ b/picosoc/spimemio.v
@@ -204,7 +204,7 @@ module spimemio (
 
 	reg [3:0] state;
 
-	reg [9:0] wakeup_ctr;
+	reg [11:0] wakeup_ctr;
 
 	always @(posedge clk) begin
 		xfer_resetn <= 1;
@@ -270,8 +270,9 @@ module spimemio (
 					// SPI flash chips that support power-down typically require
 					// some time to wake up before they can respond to commands
 					// (e.g. 3us For W25Q128JVSIM)
-					// This counter wastes 1024 clock cyles
-					// This is 102.4us at 10MHz, and 5.12us at 200MHz
+					// (e.g. 30us For MT25QL128ABA1ESE-0SIT)
+					// This counter wastes 2^12 clock cyles
+					// I.E. 41us at 100MHz, and 410us at 10MHz
 					// This range should cover all conceivable use cases
 					if(&wakeup_ctr) begin
 						state <= 5;

--- a/picosoc/spimemio.v
+++ b/picosoc/spimemio.v
@@ -204,6 +204,8 @@ module spimemio (
 
 	reg [3:0] state;
 
+	reg [9:0] wakeup_ctr;
+
 	always @(posedge clk) begin
 		xfer_resetn <= 1;
 		din_valid <= 0;
@@ -217,6 +219,7 @@ module spimemio (
 			din_qspi <= 0;
 			din_ddr <= 0;
 			din_rd <= 0;
+			wakeup_ctr <= 0;
 		end else begin
 			if (dout_valid && dout_tag == 1) buffer[ 7: 0] <= dout_data;
 			if (dout_valid && dout_tag == 2) buffer[15: 8] <= dout_data;
@@ -264,6 +267,18 @@ module spimemio (
 					end
 				end
 				4: begin
+					// SPI flash chips that support power-down typically require
+					// some time to wake up before they can respond to commands
+					// (e.g. 3us For W25Q128JVSIM)
+					// This counter wastes 1024 clock cyles
+					// This is 102.4us at 10MHz, and 5.12us at 200MHz
+					// This range should cover all conceivable use cases
+					if(&wakeup_ctr) begin
+						state <= 5;
+					end
+					wakeup_ctr <= wakeup_ctr + 1;
+				end
+				5: begin
 					rd_inc <= 0;
 					din_valid <= 1;
 					din_tag <= 0;
@@ -275,10 +290,10 @@ module spimemio (
 					endcase
 					if (din_ready) begin
 						din_valid <= 0;
-						state <= 5;
+						state <= 6;
 					end
 				end
-				5: begin
+				6: begin
 					if (valid && !ready) begin
 						din_valid <= 1;
 						din_tag <= 0;
@@ -287,30 +302,30 @@ module spimemio (
 						din_ddr <= config_ddr;
 						if (din_ready) begin
 							din_valid <= 0;
-							state <= 6;
+							state <= 7;
 						end
 					end
 				end
-				6: begin
+				7: begin
 					din_valid <= 1;
 					din_tag <= 0;
 					din_data <= addr[15:8];
 					if (din_ready) begin
 						din_valid <= 0;
-						state <= 7;
+						state <= 8;
 					end
 				end
-				7: begin
+				8: begin
 					din_valid <= 1;
 					din_tag <= 0;
 					din_data <= addr[7:0];
 					if (din_ready) begin
 						din_valid <= 0;
 						din_data <= 0;
-						state <= config_qspi || config_ddr ? 8 : 9;
+						state <= config_qspi || config_ddr ? 9 : 10;
 					end
 				end
-				8: begin
+				9: begin
 					din_valid <= 1;
 					din_tag <= 0;
 					din_data <= config_cont ? 8'h A5 : 8'h FF;
@@ -318,21 +333,12 @@ module spimemio (
 						din_rd <= 1;
 						din_data <= config_dummy;
 						din_valid <= 0;
-						state <= 9;
-					end
-				end
-				9: begin
-					din_valid <= 1;
-					din_tag <= 1;
-					if (din_ready) begin
-						din_valid <= 0;
 						state <= 10;
 					end
 				end
 				10: begin
 					din_valid <= 1;
-					din_data <= 8'h 00;
-					din_tag <= 2;
+					din_tag <= 1;
 					if (din_ready) begin
 						din_valid <= 0;
 						state <= 11;
@@ -340,19 +346,28 @@ module spimemio (
 				end
 				11: begin
 					din_valid <= 1;
-					din_tag <= 3;
+					din_data <= 8'h 00;
+					din_tag <= 2;
 					if (din_ready) begin
 						din_valid <= 0;
 						state <= 12;
 					end
 				end
 				12: begin
+					din_valid <= 1;
+					din_tag <= 3;
+					if (din_ready) begin
+						din_valid <= 0;
+						state <= 13;
+					end
+				end
+				13: begin
 					if (!rd_wait || valid) begin
 						din_valid <= 1;
 						din_tag <= 4;
 						if (din_ready) begin
 							din_valid <= 0;
-							state <= 9;
+							state <= 10;
 						end
 					end
 				end
@@ -363,9 +378,9 @@ module spimemio (
 				rd_valid <= 0;
 				xfer_resetn <= 0;
 				if (config_cont) begin
-					state <= 5;
+					state <= 6;
 				end else begin
-					state <= 4;
+					state <= 5;
 					din_qspi <= 0;
 					din_ddr <= 0;
 				end


### PR DESCRIPTION
SPI flash chips which support entering the power-down state require a delay after the release from power down command (ABh) before they are operational. This PR implements that delay for picosoc, where previously no delay was present. Without this PR I found that my board was able to boot reliably with a 10 MHz system clock, but not 25 MHz, despite being out of spec at both rates.

I looked at a few different SPI flash chips to find a reasonable delay:
- The chip I am using on my board (W25Q128JVS) requires 3us
- The chip used in ICEBreaker (W25Q128JVSIM) requires 3us
- A Micron chip that was is readily available ( MT25QL128ABA1ESE-0SIT) requires 30us
- The chip fitted to the Lattice HX8K breakout board (N25Q032A13ESC40F) doesn't support the power-down mode.

To try and account for all reasonable delays without being excessive, I have chosen 2^12 cycles. It meets the Micron required delay at 100MHz, whilst being less than 0.5ms at 10MHz. I'm happy to change this to be a parameter if you would prefer.

N.B. I have only tested this in simulation, and with my custom PCB using the default single bit wide I/O mode. I haven't tested with an ICEBreaker, or the Lattice dev board.