### PR TITLE
Fixed fusesoc parse error in picorv32.core

### DIFF
--- a/picorv32.core
+++ b/picorv32.core
@@ -8,7 +8,7 @@ filesets:
   tb:
     files: [testbench.v]
     file_type : verilogSource
-    depend:
+    depend: []
   tb_ez:
     files: [testbench_ez.v]
     file_type : verilogSource


### PR DESCRIPTION
A fix of the fusesoc parser on picorv32.core:11. Even if "depend" is empty it should be an empty array.