### PR TITLE
Fix the icebreaker example

### DIFF
--- a/picosoc/.gitignore
+++ b/picosoc/.gitignore
@@ -15,6 +15,7 @@
 /icebreaker.asc
 /icebreaker.bin
 /icebreaker.json
+/icebreaker_syn.json
 /icebreaker.log
 /icebreaker.rpt
 /icebreaker_syn.v

--- a/picosoc/Makefile
+++ b/picosoc/Makefile
@@ -56,20 +56,28 @@ icebsim: icebreaker_tb.vvp icebreaker_fw.hex
 icebsynsim: icebreaker_syn_tb.vvp icebreaker_fw.hex
 	vvp -N $< +firmware=icebreaker_fw.hex
 
+# Simulation takes a long time, so we reduce the RAM size in simulations to reduce the RAM initialization time in the
+# The uut will already be synthesized when it reaches the testbench, and therefore will not be parametrizable anymore.
+# Thus we need to synthesize with reduced RAM already applied.
+# But for the real target, we want to use the complete RAM.
 icebreaker.json: icebreaker.v ice40up5k_spram.v spimemio.v simpleuart.v picosoc.v ../picorv32.v
-	yosys -ql icebreaker.log -p 'synth_ice40 -dsp -top icebreaker -json icebreaker.json' $^
+	echo "WARNING: MEM_WORDS is altered to 256"
+	yosys -ql icebreaker.log -p 'read_verilog $^; chparam -set MEM_WORDS 256 icebreaker; synth_ice40 -dsp -top icebreaker -json icebreaker.json'
 
 icebreaker_tb.vvp: icebreaker_tb.v icebreaker.v ice40up5k_spram.v spimemio.v simpleuart.v picosoc.v ../picorv32.v spiflash.v
 	iverilog -s testbench -o $@ $^ `yosys-config --datdir/ice40/cells_sim.v` -DNO_ICE40_DEFAULT_ASSIGNMENTS
 
 icebreaker_syn_tb.vvp: icebreaker_tb.v icebreaker_syn.v spiflash.v
-	iverilog -s testbench -o $@ $^ `yosys-config --datdir/ice40/cells_sim.v` -DNO_ICE40_DEFAULT_ASSIGNMENTS
+	iverilog -s testbench -o $@ $^ `yosys-config --datdir/ice40/cells_sim.v` -DNO_ICE40_DEFAULT_ASSIGNMENTS -DRUN_SYNTH
 
 icebreaker_syn.v: icebreaker.json
 	yosys -p 'read_json icebreaker.json; write_verilog icebreaker_syn.v'
 
-icebreaker.asc: icebreaker.pcf icebreaker.json
-	nextpnr-ice40 --freq 13 --up5k --package sg48 --asc icebreaker.asc --pcf icebreaker.pcf --json icebreaker.json
+icebreaker_syn.json: icebreaker.v ice40up5k_spram.v spimemio.v simpleuart.v picosoc.v ../picorv32.v
+	yosys -ql icebreaker.log -p 'synth_ice40 -dsp -top icebreaker -json icebreaker_syn.json' $^
+
+icebreaker.asc: icebreaker.pcf icebreaker_syn.json
+	nextpnr-ice40 --freq 12 --up5k --package sg48 --asc icebreaker.asc --pcf icebreaker.pcf --json icebreaker_syn.json
 
 icebreaker.bin: icebreaker.asc
 	icetime -d up5k -c 12 -mtr icebreaker.rpt icebreaker.asc
@@ -117,6 +125,7 @@ clean:
 	rm -f hx8kdemo_syn.v hx8kdemo_syn_tb.vvp hx8kdemo_tb.vvp
 	rm -f icebreaker.json icebreaker.log icebreaker.asc icebreaker.rpt icebreaker.bin
 	rm -f icebreaker_syn.v icebreaker_syn_tb.vvp icebreaker_tb.vvp
+	rm -f icebreaker_syn.json
 
 .PHONY: spiflash_tb clean
 .PHONY: hx8kprog hx8kprog_fw hx8ksim hx8ksynsim

--- a/picosoc/icebreaker.v
+++ b/picosoc/icebreaker.v
@@ -110,7 +110,14 @@ module icebreaker (
 		.BARREL_SHIFTER(0),
 		.ENABLE_MUL(0),
 		.ENABLE_DIV(0),
-		.ENABLE_FAST_MUL(1),
+		.ENABLE_FAST_MUL(0),
+		.ENABLE_COUNTERS(1),
+		.ENABLE_COUNTERS64(0),
+		.ENABLE_REGS_16_31(1),
+		.ENABLE_REGS_DUALPORT(1),
+		.TWO_STAGE_SHIFT(0),
+		.CATCH_MISALIGN(1),
+		.CATCH_ILLINSN(1),
 		.MEM_WORDS(MEM_WORDS)
 	) soc (
 		.clk          (clk         ),

--- a/picosoc/icebreaker_tb.v
+++ b/picosoc/icebreaker_tb.v
@@ -63,10 +63,12 @@ module testbench;
 	end
 
 	icebreaker #(
-		// We limit the amount of memory in simulation
-		// in order to avoid reduce simulation time
-		// required for intialization of RAM
+	`ifndef RUN_SYNTH
+	// We limit the amount of memory in simulation
+	// in order to avoid reduce simulation time
+	// required for initialization of RAM
 		.MEM_WORDS(256)
+	`endif
 	) uut (
 		.clk      (clk      ),
 		.led1     (led1     ),

--- a/picosoc/picosoc.v
+++ b/picosoc/picosoc.v
@@ -74,8 +74,14 @@ module picosoc (
 	parameter [0:0] ENABLE_DIV = 1;
 	parameter [0:0] ENABLE_FAST_MUL = 0;
 	parameter [0:0] ENABLE_COMPRESSED = 1;
+	parameter [0:0] ENABLE_COUNTERS64 = 1;
 	parameter [0:0] ENABLE_COUNTERS = 1;
+	parameter [0:0] ENABLE_REGS_16_31 = 1;
 	parameter [0:0] ENABLE_IRQ_QREGS = 0;
+	parameter [0:0] ENABLE_REGS_DUALPORT = 0;
+	parameter [0:0] TWO_STAGE_SHIFT = 0;
+ 	parameter [0:0] CATCH_MISALIGN = 1;
+	parameter [0:0] CATCH_ILLINSN = 1;
 
 	parameter integer MEM_WORDS = 256;
 	parameter [31:0] STACKADDR = (4*MEM_WORDS);       // end of memory
@@ -142,7 +148,13 @@ module picosoc (
 		.ENABLE_DIV(ENABLE_DIV),
 		.ENABLE_FAST_MUL(ENABLE_FAST_MUL),
 		.ENABLE_IRQ(1),
-		.ENABLE_IRQ_QREGS(ENABLE_IRQ_QREGS)
+		.ENABLE_IRQ_QREGS(ENABLE_IRQ_QREGS),
+		.ENABLE_COUNTERS64(ENABLE_COUNTERS64),
+		.ENABLE_REGS_16_31(ENABLE_REGS_16_31),
+		.ENABLE_REGS_DUALPORT(ENABLE_REGS_DUALPORT),
+		.TWO_STAGE_SHIFT(TWO_STAGE_SHIFT),
+		.CATCH_MISALIGN(CATCH_MISALIGN),
+		.CATCH_ILLINSN(CATCH_ILLINSN)
 	) cpu (
 		.clk         (clk        ),
 		.resetn      (resetn     ),


### PR DESCRIPTION
Fix that it actually fits on the target.
Fix testbench failing, due to MEM_WORDS parameter not being used on the synthesized uut.  Due to unknown parameters in never versions of icarus resulting in errors instead of "warnings". Split build of syn simulated target and actual target. Fix pnr frequency check bound
Expose more picosoc  parameters.
Disable wrongfully enabled ENABLE_FAST_MUL in icebreaker.